### PR TITLE
Patched dhall-json-1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ These packages are supported by `etlas`.
 - [deepseq-1.4.2.0](https://hackage.haskell.org/package/deepseq-1.4.2.0)
 - [deepseq-generics-0.2.0.0](https://hackage.haskell.org/package/deepseq-generics-0.2.0.0)
 - [dhall >= 1.14.0](https://hackage.haskell.org/package/dhall-1.14.0)
+- [dhall-json >= 1.2.1](https://hackage.haskell.org/package/dhall-json-1.2.1)
 - [diagrams-solve-0.1.1](https://hackage.haskell.org/package/diagrams-solve-0.1.1)
 - [digest 0.0.1.2](https://hackage.haskell.org/package/digest)
 - [directory >= 1.3.0.0 && <= 1.3.1.0](https://hackage.haskell.org/package/directory)

--- a/patches/dhall-json-1.2.1.cabal
+++ b/patches/dhall-json-1.2.1.cabal
@@ -1,0 +1,73 @@
+Name: dhall-json
+Version: 1.2.1
+Cabal-Version: >=1.8.0.2
+Build-Type: Simple
+Tested-With: GHC == 7.10.2, GHC == 8.0.1
+License: BSD3
+License-File: LICENSE
+Copyright: 2017 Gabriel Gonzalez
+Author: Gabriel Gonzalez
+Maintainer: Gabriel439@gmail.com
+Bug-Reports: https://github.com/dhall-lang/dhall-json/issues
+Synopsis: Compile Dhall to JSON or YAML
+Description:
+    Use this package if you want to compile Dhall expressions to JSON or YAML.
+    You can use this package as a library or an executable:
+    .
+    * See the "Dhall.JSON" module if you want to use this package as a library
+    .
+    * Use the @dhall-to-json@ or @dhall-to-yaml@ programs from this package if
+      you want an executable
+    .
+    The "Dhall.JSON" module also contains instructions for how to use this
+    package
+Category: Compiler
+Source-Repository head
+    Type: git
+    Location: https://github.com/dhall-lang/dhall-json
+
+Library
+    Hs-Source-Dirs: src
+    Build-Depends:
+        base                      >= 4.8.0.0  && < 5   ,
+        aeson                     >= 1.0.0.0  && < 1.5 ,
+        dhall                     >= 1.15.0   && < 1.16,
+        insert-ordered-containers                < 1.14,
+        optparse-applicative      >= 0.14.0.0 && < 0.15,
+        text                      >= 0.11.1.0 && < 1.3 ,
+        unordered-containers                     < 0.3
+    Exposed-Modules: Dhall.JSON
+    GHC-Options: -Wall
+
+Executable dhall-to-json
+    Hs-Source-Dirs: dhall-to-json
+    Main-Is: Main.hs
+    Build-Depends:
+        base                       ,
+        aeson                      ,
+        aeson-pretty         < 0.9 ,
+        bytestring           < 0.11,
+        dhall                      ,
+        dhall-json                 ,
+        optparse-applicative       ,
+        text
+    GHC-Options: -Wall
+
+Executable dhall-to-yaml
+    Hs-Source-Dirs: dhall-to-yaml
+    Main-Is: Main.hs
+    Build-Depends:
+        base                                  ,
+        aeson                                 ,
+        bytestring                      < 0.11,
+        dhall                                 ,
+        dhall-json                            ,
+        optparse-applicative                  ,
+        utf8-string      >= 1.0      && <= 1.1,
+        -- yaml             >= 0.5.0    && < 0.9 ,
+        text
+    GHC-Options: -Wall
+    Maven-Depends: com.fasterxml.jackson.core:jackson-core:2.9.6,
+                   com.fasterxml.jackson.core:jackson-databind:2.9.6,
+                   com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6
+    Java-Sources: java/Utils.java

--- a/patches/dhall-json-1.2.1.patch
+++ b/patches/dhall-json-1.2.1.patch
@@ -1,0 +1,108 @@
+From 2ba1d411bd22b3042aa0c5f9a8a98551672c6bae Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Sun, 8 Jul 2018 01:08:59 +0200
+Subject: [PATCH] Patched using jackson to encode yaml
+
+---
+ dhall-json.cabal      |  8 +++++++-
+ dhall-to-yaml/Main.hs | 17 +++++++++++------
+ java/Utils.java       | 17 +++++++++++++++++
+ 3 files changed, 35 insertions(+), 7 deletions(-)
+ create mode 100644 java/Utils.java
+
+diff --git a/dhall-json.cabal b/dhall-json.cabal
+index f16d238..9249fe6 100644
+--- a/dhall-json.cabal
++++ b/dhall-json.cabal
+@@ -58,10 +58,16 @@ Executable dhall-to-yaml
+     Main-Is: Main.hs
+     Build-Depends:
+         base                                  ,
++        aeson                                 ,
+         bytestring                      < 0.11,
+         dhall                                 ,
+         dhall-json                            ,
+         optparse-applicative                  ,
+-        yaml             >= 0.5.0    && < 0.9 ,
++        utf8-string      >= 1.0      && <= 1.1,
++        -- yaml             >= 0.5.0    && < 0.9 ,
+         text
+     GHC-Options: -Wall
++    Maven-Depends: com.fasterxml.jackson.core:jackson-core:2.9.6,
++                   com.fasterxml.jackson.core:jackson-databind:2.9.6,
++                   com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.6
++    Java-Sources: java/Utils.java
+\ No newline at end of file
+diff --git a/dhall-to-yaml/Main.hs b/dhall-to-yaml/Main.hs
+index 56b7485..c9483fa 100644
+--- a/dhall-to-yaml/Main.hs
++++ b/dhall-to-yaml/Main.hs
+@@ -1,6 +1,7 @@
+-{-# LANGUAGE ApplicativeDo     #-}
+-{-# LANGUAGE OverloadedStrings #-}
+-{-# LANGUAGE RecordWildCards   #-}
++{-# LANGUAGE ApplicativeDo            #-}
++{-# LANGUAGE OverloadedStrings        #-}
++{-# LANGUAGE RecordWildCards          #-}
++{-# LANGUAGE ForeignFunctionInterface #-}
+ 
+ module Main where
+ 
+@@ -10,9 +11,10 @@ import Dhall.JSON (Conversion)
+ import Options.Applicative (Parser, ParserInfo)
+ 
+ import qualified Control.Exception
+-import qualified Data.ByteString
++import qualified Data.Aeson
++import qualified Data.ByteString.Lazy.UTF8
+ import qualified Data.Text.IO
+-import qualified Data.Yaml
++-- import qualified Data.Yaml
+ import qualified Dhall
+ import qualified Dhall.JSON
+ import qualified GHC.IO.Encoding
+@@ -53,6 +55,9 @@ parserInfo =
+         <>  Options.Applicative.progDesc "Compile Dhall to YAML"
+         )
+ 
++foreign import java unsafe "@static Utils.jsonToYaml" jsonToYaml
++  :: String -> String
++
+ main :: IO ()
+ main = do
+     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
+@@ -68,7 +73,7 @@ main = do
+ 
+         json <- omittingNull <$> explaining (Dhall.JSON.codeToValue conversion "(stdin)" stdin)
+ 
+-        Data.ByteString.putStr $ Data.Yaml.encode json 
++        putStr $ jsonToYaml $ Data.ByteString.Lazy.UTF8.toString $ Data.Aeson.encode json 
+ 
+ handle :: IO a -> IO a
+ handle = Control.Exception.handle handler
+diff --git a/java/Utils.java b/java/Utils.java
+new file mode 100644
+index 0000000..6f8c233
+--- /dev/null
++++ b/java/Utils.java
+@@ -0,0 +1,17 @@
++import java.io.IOException;
++
++import com.fasterxml.jackson.core.JsonProcessingException;
++import com.fasterxml.jackson.databind.JsonNode;
++import com.fasterxml.jackson.databind.ObjectMapper;
++import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
++
++public class Utils {
++
++    public static String jsonToYaml (String jsonString) throws
++        JsonProcessingException, IOException {
++        JsonNode jsonNodeTree = new ObjectMapper().readTree(jsonString);
++        String jsonAsYaml = new YAMLMapper().writeValueAsString(jsonNodeTree);
++        return jsonAsYaml;
++    }
++    
++}
+-- 
+2.16.2.windows.1
+


### PR DESCRIPTION
* This patch is to make work dhall-to-yaml (the lib and dhall-to-json works as is with eta)
* The issue is with the [yaml package](https://github.com/snoyberg/yaml/)  that depends heavily on a c library
* The hack had been convert dhall to a json string and use the java lib jackson to convert it to yaml