### PR TITLE
fix interrupted status in accept() in `network`

### DIFF
--- a/patches/network-2.6.3.2.patch
+++ b/patches/network-2.6.3.2.patch
@@ -1,37 +1,27 @@
-From 45079046fe774dfd41fc4536621bdd5a81d36d06 Mon Sep 17 00:00:00 2001
-From: Rahul Muttineni <rahulmutt@gmail.com>
-Date: Wed, 6 Jun 2018 19:29:59 +0530
+From 8d70d4bf1085391b8bc3dbfba00a9805227dcc3c Mon Sep 17 00:00:00 2001
+From: monser <ouromoros@gmail.com>
+Date: Tue, 24 Jul 2018 14:24:28 +0800
 Subject: [PATCH] Patched
 
 ---
- Network.hs                            |   49 +-
- Network/BSD.hs                        |  393 ++++++++
- Network/BSD.hsc                       |  589 ------------
- Network/Socket.hs                     | 1491 +++++++++++++++++++++++++++++
- Network/Socket.hsc                    | 1683 ---------------------------------
- Network/Socket/ByteString.hs          |  263 ++++++
- Network/Socket/ByteString.hsc         |  338 -------
- Network/Socket/ByteString/Internal.hs |   21 -
- Network/Socket/ByteString/Lazy.hs     |    4 -
- Network/Socket/Internal.hs            |  268 ++++++
- Network/Socket/Internal.hsc           |  274 ------
- Network/Socket/Types.hs               | 1001 ++++++++++++++++++++
- Network/Socket/Types.hsc              | 1111 ----------------------
- include/HsNet.h                       |  359 +++----
- include/HsNetworkConfig.h             |  178 ----
- java/Utils.java                       |  192 ++++
- network.cabal                         |   26 +-
- 17 files changed, 3827 insertions(+), 4413 deletions(-)
- create mode 100644 Network/BSD.hs
- delete mode 100644 Network/BSD.hsc
- create mode 100644 Network/Socket.hs
- delete mode 100644 Network/Socket.hsc
- create mode 100644 Network/Socket/ByteString.hs
- delete mode 100644 Network/Socket/ByteString.hsc
- create mode 100644 Network/Socket/Internal.hs
- delete mode 100644 Network/Socket/Internal.hsc
- create mode 100644 Network/Socket/Types.hs
- delete mode 100644 Network/Socket/Types.hsc
+ Network.hs                                    |  49 +-
+ Network/{BSD.hsc => BSD.hs}                   | 242 +-----
+ Network/{Socket.hsc => Socket.hs}             | 692 +++++++-----------
+ .../Socket/{ByteString.hsc => ByteString.hs}  |  75 --
+ Network/Socket/ByteString/Internal.hs         |  21 -
+ Network/Socket/ByteString/Lazy.hs             |   4 -
+ Network/Socket/{Internal.hsc => Internal.hs}  |  20 +-
+ Network/Socket/{Types.hsc => Types.hs}        | 386 ++++------
+ include/HsNet.h                               | 359 ++++-----
+ include/HsNetworkConfig.h                     | 178 -----
+ java/Utils.java                               | 193 +++++
+ network.cabal                                 |  26 +-
+ 12 files changed, 830 insertions(+), 1415 deletions(-)
+ rename Network/{BSD.hsc => BSD.hs} (56%)
+ rename Network/{Socket.hsc => Socket.hs} (71%)
+ rename Network/Socket/{ByteString.hsc => ByteString.hs} (77%)
+ rename Network/Socket/{Internal.hsc => Internal.hs} (95%)
+ rename Network/Socket/{Types.hsc => Types.hs} (73%)
  delete mode 100644 include/HsNetworkConfig.h
  create mode 100644 java/Utils.java
 
@@ -163,557 +153,17 @@ index 8fb8d92..38006df 100644
 +
 +-- foreign import java unsafe "@static eta.network.Utils.getHostsByAddr"
 +--   getHostsByAddr :: Word32 -> IO Socket.InetAddressArray
-diff --git a/Network/BSD.hs b/Network/BSD.hs
-new file mode 100644
-index 0000000..5b78bd8
---- /dev/null
-+++ b/Network/BSD.hs
-@@ -0,0 +1,393 @@
-+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
-+-----------------------------------------------------------------------------
-+-- |
-+-- Module      :  Network.BSD
-+-- Copyright   :  (c) The University of Glasgow 2001
-+-- License     :  BSD-style (see the file libraries/network/LICENSE)
-+--
-+-- Maintainer  :  libraries@haskell.org
-+-- Stability   :  experimental
-+-- Portability :  non-portable
-+--
-+-- The "Network.BSD" module defines Haskell bindings to network
-+-- programming functionality provided by BSD Unix derivatives.
-+--
-+-----------------------------------------------------------------------------
-+
-+#include "HsNet.h"
-+
-+module Network.BSD
-+    (
-+    -- * Host names
-+      HostName
-+    , getHostName
-+
-+    , HostEntry(..)
-+    , getHostByName
-+    , getHostByAddr
-+    , hostAddress
-+
-+#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
-+    , getHostEntries
-+
-+    -- ** Low level functionality
-+    , setHostEntry
-+    , getHostEntry
-+    , endHostEntry
-+#endif
-+
-+    -- * Service names
-+    , ServiceEntry(..)
-+    , ServiceName
-+    , getServiceByName
-+    , getServiceByPort
-+    , getServicePortNumber
-+
-+#if !defined(mingw32_HOST_OS)
-+    , getServiceEntries
-+
-+    -- ** Low level functionality
-+    , getServiceEntry
-+    , setServiceEntry
-+    , endServiceEntry
-+#endif
-+
-+    -- * Protocol names
-+    , ProtocolName
-+    , ProtocolNumber
-+    , ProtocolEntry(..)
-+    , getProtocolByName
-+    , getProtocolByNumber
-+    , getProtocolNumber
-+    , defaultProtocol
-+
-+#if !defined(mingw32_HOST_OS)
-+    , getProtocolEntries
-+    -- ** Low level functionality
-+    , setProtocolEntry
-+    , getProtocolEntry
-+    , endProtocolEntry
-+#endif
-+
-+    -- * Port numbers
-+    , PortNumber
-+
-+    -- * Network names
-+    , NetworkName
-+    , NetworkAddr
-+    , NetworkEntry(..)
-+
-+#if !defined(mingw32_HOST_OS)
-+    , getNetworkByName
-+    , getNetworkByAddr
-+    , getNetworkEntries
-+    -- ** Low level functionality
-+    , setNetworkEntry
-+    , getNetworkEntry
-+    , endNetworkEntry
-+#endif
-+
-+#if defined(HAVE_IF_NAMETOINDEX)
-+    -- * Interface names
-+    , ifNameToIndex
-+#endif
-+
-+    ) where
-+
-+import Network.Socket
-+
-+import Control.Concurrent (MVar, newMVar, withMVar)
-+import qualified Control.Exception as E
-+import Foreign.C.String (CString, peekCString, withCString)
-+#if defined(HAVE_WINSOCK2_H)
-+import Foreign.C.Types ( CShort )
-+#endif
-+import Foreign.C.Types ( CInt(..), CUInt(..), CULong(..), CSize(..) )
-+import Foreign.Ptr (Ptr, nullPtr)
-+import Foreign.Storable (Storable(..))
-+import Foreign.Marshal.Array (allocaArray0, peekArray0)
-+import Foreign.Marshal.Utils (with, fromBool)
-+import Data.Typeable
-+import System.IO.Error (ioeSetErrorString, mkIOError)
-+import System.IO.Unsafe (unsafePerformIO)
-+
-+import GHC.IO.Exception
-+
-+import Control.Monad (liftM)
-+
-+import Network.Socket.Internal (throwSocketErrorIfMinus1_)
-+
-+-- ---------------------------------------------------------------------------
-+-- Basic Types
-+
-+type ProtocolName = String
-+
-+-- ---------------------------------------------------------------------------
-+-- Service Database Access
-+
-+-- Calling getServiceByName for a given service and protocol returns
-+-- the systems service entry.  This should be used to find the port
-+-- numbers for standard protocols such as SMTP and FTP.  The remaining
-+-- three functions should be used for browsing the service database
-+-- sequentially.
-+
-+-- Calling setServiceEntry with True indicates that the service
-+-- database should be left open between calls to getServiceEntry.  To
-+-- close the database a call to endServiceEntry is required.  This
-+-- database file is usually stored in the file /etc/services.
-+
-+data ServiceEntry  =
-+  ServiceEntry  {
-+     serviceName     :: ServiceName,    -- Official Name
-+     serviceAliases  :: [ServiceName],  -- aliases
-+     servicePort     :: PortNumber,     -- Port Number  ( network byte order )
-+     serviceProtocol :: ProtocolName    -- Protocol
-+  } deriving (Show, Typeable)
-+
-+-- | Get service by name.
-+getServiceByName :: ServiceName         -- Service Name
-+                 -> ProtocolName        -- Protocol Name
-+                 -> IO ServiceEntry     -- Service Entry
-+getServiceByName name proto = error "getServiceByName: Not implemented yet."
-+
-+-- | Get the service given a 'PortNumber' and 'ProtocolName'.
-+getServiceByPort :: PortNumber -> ProtocolName -> IO ServiceEntry
-+getServiceByPort port proto = error "getServiceByPort: Not implemented yet."
-+
-+-- | Get the 'PortNumber' corresponding to the 'ServiceName'.
-+getServicePortNumber :: ServiceName -> IO PortNumber
-+getServicePortNumber name = error "getServiceByPort: Not implemented yet."
-+
-+#if !defined(mingw32_HOST_OS)
-+getServiceEntry :: IO ServiceEntry
-+getServiceEntry = error "getServiceEntry: Not implemented yet."
-+
-+setServiceEntry :: Bool -> IO ()
-+setServiceEntry flg = error "setServiceEntry: Not implemented yet."
-+
-+endServiceEntry :: IO ()
-+endServiceEntry = error "endServiceEntry: Not implemented yet."
-+
-+getServiceEntries :: Bool -> IO [ServiceEntry]
-+getServiceEntries stayOpen = do
-+  setServiceEntry stayOpen
-+  getEntries (getServiceEntry) (endServiceEntry)
-+#endif
-+
-+-- ---------------------------------------------------------------------------
-+-- Protocol Entries
-+
-+-- The following relate directly to the corresponding UNIX C
-+-- calls for returning the protocol entries. The protocol entry is
-+-- represented by the Haskell type ProtocolEntry.
-+
-+-- As for setServiceEntry above, calling setProtocolEntry.
-+-- determines whether or not the protocol database file, usually
-+-- @/etc/protocols@, is to be kept open between calls of
-+-- getProtocolEntry. Similarly,
-+
-+data ProtocolEntry =
-+  ProtocolEntry  {
-+     protoName    :: ProtocolName,      -- Official Name
-+     protoAliases :: [ProtocolName],    -- aliases
-+     protoNumber  :: ProtocolNumber     -- Protocol Number
-+  } deriving (Read, Show, Typeable)
-+
-+getProtocolByName :: ProtocolName -> IO ProtocolEntry
-+getProtocolByName name = error "getProtocolByName: Not implemented yet."
-+
-+getProtocolByNumber :: ProtocolNumber -> IO ProtocolEntry
-+getProtocolByNumber num = error "getProtocolByNumber: Not implemented yet."
-+
-+-- TODO: The protocol number is currently unusued so this
-+--       should be OK.
-+getProtocolNumber :: ProtocolName -> IO ProtocolNumber
-+getProtocolNumber "tcp" = return 6
-+getProtocolNumber _ = error "getProtocolNumber: Not implemented yet for non-tcp protocols."
-+
-+#if !defined(mingw32_HOST_OS)
-+getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
-+getProtocolEntry = error "getProtocolEntry: Not implemented yet."
-+
-+setProtocolEntry :: Bool -> IO ()       -- Keep DB Open ?
-+setProtocolEntry flg = error "setProtocolEntry: Not implemented yet."
-+
-+endProtocolEntry :: IO ()
-+endProtocolEntry = error "endProtocolEntry: Not implemented yet."
-+
-+getProtocolEntries :: Bool -> IO [ProtocolEntry]
-+getProtocolEntries stayOpen = withLock $ do
-+  setProtocolEntry stayOpen
-+  getEntries (getProtocolEntry) (endProtocolEntry)
-+#endif
-+
-+-- ---------------------------------------------------------------------------
-+-- Host lookups
-+
-+data HostEntry =
-+  HostEntry  {
-+     hostName      :: HostName,         -- Official Name
-+     hostAliases   :: [HostName],       -- aliases
-+     hostFamily    :: Family,           -- Host Type (currently AF_INET)
-+     hostAddresses :: [HostAddress]     -- Set of Network Addresses  (in network byte order)
-+  } deriving (Read, Show, Typeable)
-+
-+-- convenience function:
-+hostAddress :: HostEntry -> HostAddress
-+hostAddress (HostEntry nm _ _ ls) =
-+ case ls of
-+   []    -> error $ "Network.BSD.hostAddress: empty network address list for " ++ nm
-+   (x:_) -> x
-+
-+-- getHostByName must use the same lock as the *hostent functions
-+-- may cause problems if called concurrently.
-+
-+-- | Resolve a 'HostName' to IPv4 address.
-+getHostByName :: HostName -> IO HostEntry
-+getHostByName name = error "getHostByName: Not implemented yet."
-+
-+-- The locking of gethostbyaddr is similar to gethostbyname.
-+-- | Get a 'HostEntry' corresponding to the given address and family.
-+-- Note that only IPv4 is currently supported.
-+getHostByAddr :: Family -> HostAddress -> IO HostEntry
-+getHostByAddr family addr = error "getHostByAddr: Not implemented yet."
-+
-+#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
-+getHostEntry :: IO HostEntry
-+getHostEntry = withLock $ do
-+ throwNoSuchThingIfNull "Network.BSD.getHostEntry" "unable to retrieve host entry"
-+   $ c_gethostent
-+ >>= peek
-+
-+foreign import ccall unsafe "gethostent" c_gethostent :: IO (Ptr HostEntry)
-+
-+setHostEntry :: Bool -> IO ()
-+setHostEntry flg = withLock $ c_sethostent (fromBool flg)
-+
-+foreign import ccall unsafe "sethostent" c_sethostent :: CInt -> IO ()
-+
-+endHostEntry :: IO ()
-+endHostEntry = withLock $ c_endhostent
-+
-+foreign import ccall unsafe "endhostent" c_endhostent :: IO ()
-+
-+getHostEntries :: Bool -> IO [HostEntry]
-+getHostEntries stayOpen = do
-+  setHostEntry stayOpen
-+  getEntries (getHostEntry) (endHostEntry)
-+#endif
-+
-+-- ---------------------------------------------------------------------------
-+-- Accessing network information
-+
-+-- Same set of access functions as for accessing host,protocol and
-+-- service system info, this time for the types of networks supported.
-+
-+-- network addresses are represented in host byte order.
-+type NetworkAddr = CULong
-+
-+type NetworkName = String
-+
-+data NetworkEntry =
-+  NetworkEntry {
-+     networkName        :: NetworkName,   -- official name
-+     networkAliases     :: [NetworkName], -- aliases
-+     networkFamily      :: Family,         -- type
-+     networkAddress     :: NetworkAddr
-+   } deriving (Read, Show, Typeable)
-+
-+
-+#if !defined(mingw32_HOST_OS)
-+getNetworkByName :: NetworkName -> IO NetworkEntry
-+getNetworkByName name = error "getNetworkByName: Not implemented yet."
-+
-+getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
-+getNetworkByAddr addr family = error "getNetworkByAddr: Not implemented yet."
-+
-+getNetworkEntry :: IO NetworkEntry
-+getNetworkEntry = error "getNetworkByEntry: Not implemented yet."
-+
-+-- | Open the network name database. The parameter specifies
-+-- whether a connection is maintained open between various
-+-- networkEntry calls
-+setNetworkEntry :: Bool -> IO ()
-+setNetworkEntry flg = error "setNetworkEntry: Not implemented yet."
-+
-+-- | Close the connection to the network name database.
-+endNetworkEntry :: IO ()
-+endNetworkEntry = error "endNetworkEntry: Not implemented yet."
-+
-+-- | Get the list of network entries.
-+getNetworkEntries :: Bool -> IO [NetworkEntry]
-+getNetworkEntries stayOpen = do
-+  setNetworkEntry stayOpen
-+  getEntries (getNetworkEntry) (endNetworkEntry)
-+#endif
-+
-+-- ---------------------------------------------------------------------------
-+-- Interface names
-+
-+#if defined(HAVE_IF_NAMETOINDEX)
-+
-+-- returns the index of the network interface corresponding to the name ifname.
-+ifNameToIndex :: String -> IO (Maybe Int)
-+ifNameToIndex ifname = do
-+  index <- withCString ifname c_if_nametoindex
-+  -- On failure zero is returned. We'll return Nothing.
-+  return $ if index == 0 then Nothing else Just $ fromIntegral index
-+
-+foreign import CALLCONV safe "if_nametoindex"
-+   c_if_nametoindex :: CString -> IO CUInt
-+
-+#endif
-+
-+
-+-- Mutex for name service lockdown
-+
-+{-# NOINLINE lock #-}
-+lock :: MVar ()
-+lock = unsafePerformIO $ withSocketsDo $ newMVar ()
-+
-+withLock :: IO a -> IO a
-+withLock act = withMVar lock (\_ -> act)
-+
-+-- ---------------------------------------------------------------------------
-+-- Miscellaneous Functions
-+
-+-- | Calling getHostName returns the standard host name for the current
-+-- processor, as set at boot time.
-+
-+getHostName :: IO HostName
-+getHostName = error "getHostName: Not implemented yet."
-+
-+-- Helper function used by the exported functions that provides a
-+-- Haskellised view of the enumerator functions:
-+
-+getEntries :: IO a  -- read
-+           -> IO () -- at end
-+           -> IO [a]
-+getEntries getOne atEnd = loop
-+  where
-+    loop = do
-+      vv <- E.catch (liftM Just getOne)
-+            (\ e -> let _types = e :: IOException in return Nothing)
-+      case vv of
-+        Nothing -> return []
-+        Just v  -> loop >>= \ vs -> atEnd >> return (v:vs)
-+
-+
-+throwNoSuchThingIfNull :: String -> String -> IO (Ptr a) -> IO (Ptr a)
-+throwNoSuchThingIfNull loc desc act = do
-+  ptr <- act
-+  if (ptr == nullPtr)
-+   then ioError (ioeSetErrorString (mkIOError NoSuchThing loc Nothing Nothing) desc)
-+   else return ptr
-+
-+throwUnsupportedOperationPoke :: String -> Ptr a -> a -> IO ()
-+throwUnsupportedOperationPoke typ _ _ =
-+  ioError $ ioeSetErrorString ioe "Operation not implemented"
-+  where
-+    ioe = mkIOError UnsupportedOperation
-+                    ("Network.BSD: instance Storable " ++ typ ++ ": poke")
-+                    Nothing
-+                    Nothing
-diff --git a/Network/BSD.hsc b/Network/BSD.hsc
-deleted file mode 100644
-index 8d38dab..0000000
+diff --git a/Network/BSD.hsc b/Network/BSD.hs
+similarity index 56%
+rename from Network/BSD.hsc
+rename to Network/BSD.hs
+index 8d38dab..5b78bd8 100644
 --- a/Network/BSD.hsc
-+++ /dev/null
-@@ -1,589 +0,0 @@
--{-# LANGUAGE CPP, ForeignFunctionInterface #-}
-------------------------------------------------------------------------------
---- |
---- Module      :  Network.BSD
---- Copyright   :  (c) The University of Glasgow 2001
---- License     :  BSD-style (see the file libraries/network/LICENSE)
----
---- Maintainer  :  libraries@haskell.org
---- Stability   :  experimental
---- Portability :  non-portable
----
---- The "Network.BSD" module defines Haskell bindings to network
---- programming functionality provided by BSD Unix derivatives.
----
-------------------------------------------------------------------------------
--
--#include "HsNet.h"
--
--module Network.BSD
--    (
--    -- * Host names
--      HostName
--    , getHostName
--
--    , HostEntry(..)
--    , getHostByName
--    , getHostByAddr
--    , hostAddress
--
--#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
--    , getHostEntries
--
--    -- ** Low level functionality
--    , setHostEntry
--    , getHostEntry
--    , endHostEntry
--#endif
--
--    -- * Service names
--    , ServiceEntry(..)
--    , ServiceName
--    , getServiceByName
--    , getServiceByPort
--    , getServicePortNumber
--
--#if !defined(mingw32_HOST_OS)
--    , getServiceEntries
--
--    -- ** Low level functionality
--    , getServiceEntry
--    , setServiceEntry
--    , endServiceEntry
--#endif
--
--    -- * Protocol names
--    , ProtocolName
--    , ProtocolNumber
--    , ProtocolEntry(..)
--    , getProtocolByName
--    , getProtocolByNumber
--    , getProtocolNumber
--    , defaultProtocol
--
--#if !defined(mingw32_HOST_OS)
--    , getProtocolEntries
--    -- ** Low level functionality
--    , setProtocolEntry
--    , getProtocolEntry
--    , endProtocolEntry
--#endif
--
--    -- * Port numbers
--    , PortNumber
--
--    -- * Network names
--    , NetworkName
--    , NetworkAddr
--    , NetworkEntry(..)
--
--#if !defined(mingw32_HOST_OS)
--    , getNetworkByName
--    , getNetworkByAddr
--    , getNetworkEntries
--    -- ** Low level functionality
--    , setNetworkEntry
--    , getNetworkEntry
--    , endNetworkEntry
--#endif
--
--#if defined(HAVE_IF_NAMETOINDEX)
--    -- * Interface names
--    , ifNameToIndex
--#endif
--
--    ) where
--
--import Network.Socket
--
--import Control.Concurrent (MVar, newMVar, withMVar)
--import qualified Control.Exception as E
--import Foreign.C.String (CString, peekCString, withCString)
--#if defined(HAVE_WINSOCK2_H)
--import Foreign.C.Types ( CShort )
--#endif
--import Foreign.C.Types ( CInt(..), CUInt(..), CULong(..), CSize(..) )
--import Foreign.Ptr (Ptr, nullPtr)
--import Foreign.Storable (Storable(..))
--import Foreign.Marshal.Array (allocaArray0, peekArray0)
--import Foreign.Marshal.Utils (with, fromBool)
--import Data.Typeable
--import System.IO.Error (ioeSetErrorString, mkIOError)
--import System.IO.Unsafe (unsafePerformIO)
--
--import GHC.IO.Exception
--
--import Control.Monad (liftM)
--
--import Network.Socket.Internal (throwSocketErrorIfMinus1_)
--
---- ---------------------------------------------------------------------------
---- Basic Types
--
--type ProtocolName = String
--
---- ---------------------------------------------------------------------------
---- Service Database Access
--
---- Calling getServiceByName for a given service and protocol returns
---- the systems service entry.  This should be used to find the port
---- numbers for standard protocols such as SMTP and FTP.  The remaining
---- three functions should be used for browsing the service database
---- sequentially.
--
---- Calling setServiceEntry with True indicates that the service
---- database should be left open between calls to getServiceEntry.  To
---- close the database a call to endServiceEntry is required.  This
---- database file is usually stored in the file /etc/services.
--
--data ServiceEntry  =
--  ServiceEntry  {
--     serviceName     :: ServiceName,    -- Official Name
--     serviceAliases  :: [ServiceName],  -- aliases
--     servicePort     :: PortNumber,     -- Port Number  ( network byte order )
--     serviceProtocol :: ProtocolName    -- Protocol
--  } deriving (Show, Typeable)
--
++++ b/Network/BSD.hs
+@@ -144,82 +144,29 @@ data ServiceEntry  =
+      serviceProtocol :: ProtocolName    -- Protocol
+   } deriving (Show, Typeable)
+ 
 -instance Storable ServiceEntry where
 -   sizeOf    _ = #const sizeof(struct servent)
 -   alignment _ = alignment (undefined :: CInt) -- ???
@@ -741,10 +191,10 @@ index 8d38dab..0000000
 -   poke = throwUnsupportedOperationPoke "ServiceEntry"
 -
 -
---- | Get service by name.
--getServiceByName :: ServiceName         -- Service Name
--                 -> ProtocolName        -- Protocol Name
--                 -> IO ServiceEntry     -- Service Entry
+ -- | Get service by name.
+ getServiceByName :: ServiceName         -- Service Name
+                  -> ProtocolName        -- Protocol Name
+                  -> IO ServiceEntry     -- Service Entry
 -getServiceByName name proto = withLock $ do
 - withCString name  $ \ cstr_name  -> do
 - withCString proto $ \ cstr_proto -> do
@@ -754,9 +204,10 @@ index 8d38dab..0000000
 -
 -foreign import CALLCONV unsafe "getservbyname"
 -  c_getservbyname :: CString -> CString -> IO (Ptr ServiceEntry)
--
---- | Get the service given a 'PortNumber' and 'ProtocolName'.
--getServiceByPort :: PortNumber -> ProtocolName -> IO ServiceEntry
++getServiceByName name proto = error "getServiceByName: Not implemented yet."
+ 
+ -- | Get the service given a 'PortNumber' and 'ProtocolName'.
+ getServiceByPort :: PortNumber -> ProtocolName -> IO ServiceEntry
 -getServiceByPort port proto = withLock $ do
 - withCString proto $ \ cstr_proto -> do
 - throwNoSuchThingIfNull "Network.BSD.getServiceByPort" "no such service entry"
@@ -765,57 +216,43 @@ index 8d38dab..0000000
 -
 -foreign import CALLCONV unsafe "getservbyport"
 -  c_getservbyport :: CInt -> CString -> IO (Ptr ServiceEntry)
--
---- | Get the 'PortNumber' corresponding to the 'ServiceName'.
--getServicePortNumber :: ServiceName -> IO PortNumber
++getServiceByPort port proto = error "getServiceByPort: Not implemented yet."
+ 
+ -- | Get the 'PortNumber' corresponding to the 'ServiceName'.
+ getServicePortNumber :: ServiceName -> IO PortNumber
 -getServicePortNumber name = do
 -    (ServiceEntry _ _ port _) <- getServiceByName name "tcp"
 -    return port
--
--#if !defined(mingw32_HOST_OS)
--getServiceEntry :: IO ServiceEntry
++getServicePortNumber name = error "getServiceByPort: Not implemented yet."
+ 
+ #if !defined(mingw32_HOST_OS)
+ getServiceEntry :: IO ServiceEntry
 -getServiceEntry = withLock $ do
 - throwNoSuchThingIfNull "Network.BSD.getServiceEntry" "no such service entry"
 -   $ c_getservent
 - >>= peek
 -
 -foreign import ccall unsafe "getservent" c_getservent :: IO (Ptr ServiceEntry)
--
--setServiceEntry :: Bool -> IO ()
++getServiceEntry = error "getServiceEntry: Not implemented yet."
+ 
+ setServiceEntry :: Bool -> IO ()
 -setServiceEntry flg = withLock $ c_setservent (fromBool flg)
 -
 -foreign import ccall unsafe  "setservent" c_setservent :: CInt -> IO ()
--
--endServiceEntry :: IO ()
++setServiceEntry flg = error "setServiceEntry: Not implemented yet."
+ 
+ endServiceEntry :: IO ()
 -endServiceEntry = withLock $ c_endservent
 -
 -foreign import ccall unsafe  "endservent" c_endservent :: IO ()
--
--getServiceEntries :: Bool -> IO [ServiceEntry]
--getServiceEntries stayOpen = do
--  setServiceEntry stayOpen
--  getEntries (getServiceEntry) (endServiceEntry)
--#endif
--
---- ---------------------------------------------------------------------------
---- Protocol Entries
--
---- The following relate directly to the corresponding UNIX C
---- calls for returning the protocol entries. The protocol entry is
---- represented by the Haskell type ProtocolEntry.
--
---- As for setServiceEntry above, calling setProtocolEntry.
---- determines whether or not the protocol database file, usually
---- @/etc/protocols@, is to be kept open between calls of
---- getProtocolEntry. Similarly,
--
--data ProtocolEntry =
--  ProtocolEntry  {
--     protoName    :: ProtocolName,      -- Official Name
--     protoAliases :: [ProtocolName],    -- aliases
--     protoNumber  :: ProtocolNumber     -- Protocol Number
--  } deriving (Read, Show, Typeable)
--
++endServiceEntry = error "endServiceEntry: Not implemented yet."
+ 
+ getServiceEntries :: Bool -> IO [ServiceEntry]
+ getServiceEntries stayOpen = do
+@@ -246,77 +193,27 @@ data ProtocolEntry =
+      protoNumber  :: ProtocolNumber     -- Protocol Number
+   } deriving (Read, Show, Typeable)
+ 
 -instance Storable ProtocolEntry where
 -   sizeOf    _ = #const sizeof(struct protoent)
 -   alignment _ = alignment (undefined :: CInt) -- ???
@@ -843,7 +280,7 @@ index 8d38dab..0000000
 -   poke = throwUnsupportedOperationPoke "ProtocolEntry"
 -
 -
--getProtocolByName :: ProtocolName -> IO ProtocolEntry
+ getProtocolByName :: ProtocolName -> IO ProtocolEntry
 -getProtocolByName name = withLock $ do
 - withCString name $ \ name_cstr -> do
 - throwNoSuchThingIfNull "Network.BSD.getProtocolByName" ("no such protocol name: " ++ name)
@@ -853,8 +290,9 @@ index 8d38dab..0000000
 -foreign import  CALLCONV unsafe  "getprotobyname"
 -   c_getprotobyname :: CString -> IO (Ptr ProtocolEntry)
 -
--
--getProtocolByNumber :: ProtocolNumber -> IO ProtocolEntry
++getProtocolByName name = error "getProtocolByName: Not implemented yet."
+ 
+ getProtocolByNumber :: ProtocolNumber -> IO ProtocolEntry
 -getProtocolByNumber num = withLock $ do
 - throwNoSuchThingIfNull "Network.BSD.getProtocolByNumber" ("no such protocol number: " ++ show num)
 -   $ c_getprotobynumber (fromIntegral num)
@@ -863,48 +301,45 @@ index 8d38dab..0000000
 -foreign import CALLCONV unsafe  "getprotobynumber"
 -   c_getprotobynumber :: CInt -> IO (Ptr ProtocolEntry)
 -
--
--getProtocolNumber :: ProtocolName -> IO ProtocolNumber
++getProtocolByNumber num = error "getProtocolByNumber: Not implemented yet."
+ 
++-- TODO: The protocol number is currently unusued so this
++--       should be OK.
+ getProtocolNumber :: ProtocolName -> IO ProtocolNumber
 -getProtocolNumber proto = do
 - (ProtocolEntry _ _ num) <- getProtocolByName proto
 - return num
--
--#if !defined(mingw32_HOST_OS)
--getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
++getProtocolNumber "tcp" = return 6
++getProtocolNumber _ = error "getProtocolNumber: Not implemented yet for non-tcp protocols."
+ 
+ #if !defined(mingw32_HOST_OS)
+ getProtocolEntry :: IO ProtocolEntry    -- Next Protocol Entry from DB
 -getProtocolEntry = withLock $ do
 - ent <- throwNoSuchThingIfNull "Network.BSD.getProtocolEntry" "no such protocol entry"
 -                $ c_getprotoent
 - peek ent
 -
 -foreign import ccall unsafe  "getprotoent" c_getprotoent :: IO (Ptr ProtocolEntry)
--
--setProtocolEntry :: Bool -> IO ()       -- Keep DB Open ?
++getProtocolEntry = error "getProtocolEntry: Not implemented yet."
+ 
+ setProtocolEntry :: Bool -> IO ()       -- Keep DB Open ?
 -setProtocolEntry flg = withLock $ c_setprotoent (fromBool flg)
 -
 -foreign import ccall unsafe "setprotoent" c_setprotoent :: CInt -> IO ()
--
--endProtocolEntry :: IO ()
++setProtocolEntry flg = error "setProtocolEntry: Not implemented yet."
+ 
+ endProtocolEntry :: IO ()
 -endProtocolEntry = withLock $ c_endprotoent
 -
 -foreign import ccall unsafe "endprotoent" c_endprotoent :: IO ()
--
--getProtocolEntries :: Bool -> IO [ProtocolEntry]
--getProtocolEntries stayOpen = withLock $ do
--  setProtocolEntry stayOpen
--  getEntries (getProtocolEntry) (endProtocolEntry)
--#endif
--
---- ---------------------------------------------------------------------------
---- Host lookups
--
--data HostEntry =
--  HostEntry  {
--     hostName      :: HostName,         -- Official Name
--     hostAliases   :: [HostName],       -- aliases
--     hostFamily    :: Family,           -- Host Type (currently AF_INET)
--     hostAddresses :: [HostAddress]     -- Set of Network Addresses  (in network byte order)
--  } deriving (Read, Show, Typeable)
--
++endProtocolEntry = error "endProtocolEntry: Not implemented yet."
+ 
+ getProtocolEntries :: Bool -> IO [ProtocolEntry]
+ getProtocolEntries stayOpen = withLock $ do
+@@ -335,34 +232,6 @@ data HostEntry =
+      hostAddresses :: [HostAddress]     -- Set of Network Addresses  (in network byte order)
+   } deriving (Read, Show, Typeable)
+ 
 -instance Storable HostEntry where
 -   sizeOf    _ = #const sizeof(struct hostent)
 -   alignment _ = alignment (undefined :: CInt) -- ???
@@ -933,18 +368,13 @@ index 8d38dab..0000000
 -   poke = throwUnsupportedOperationPoke "HostEntry"
 -
 -
---- convenience function:
--hostAddress :: HostEntry -> HostAddress
--hostAddress (HostEntry nm _ _ ls) =
-- case ls of
--   []    -> error $ "Network.BSD.hostAddress: empty network address list for " ++ nm
--   (x:_) -> x
--
---- getHostByName must use the same lock as the *hostent functions
---- may cause problems if called concurrently.
--
---- | Resolve a 'HostName' to IPv4 address.
--getHostByName :: HostName -> IO HostEntry
+ -- convenience function:
+ hostAddress :: HostEntry -> HostAddress
+ hostAddress (HostEntry nm _ _ ls) =
+@@ -375,28 +244,13 @@ hostAddress (HostEntry nm _ _ ls) =
+ 
+ -- | Resolve a 'HostName' to IPv4 address.
+ getHostByName :: HostName -> IO HostEntry
 -getHostByName name = withLock $ do
 -  withCString name $ \ name_cstr -> do
 -   ent <- throwNoSuchThingIfNull "Network.BSD.getHostByName" "no such host entry"
@@ -954,11 +384,12 @@ index 8d38dab..0000000
 -foreign import CALLCONV safe "gethostbyname"
 -   c_gethostbyname :: CString -> IO (Ptr HostEntry)
 -
--
---- The locking of gethostbyaddr is similar to gethostbyname.
---- | Get a 'HostEntry' corresponding to the given address and family.
---- Note that only IPv4 is currently supported.
--getHostByAddr :: Family -> HostAddress -> IO HostEntry
++getHostByName name = error "getHostByName: Not implemented yet."
+ 
+ -- The locking of gethostbyaddr is similar to gethostbyname.
+ -- | Get a 'HostEntry' corresponding to the given address and family.
+ -- Note that only IPv4 is currently supported.
+ getHostByAddr :: Family -> HostAddress -> IO HostEntry
 -getHostByAddr family addr = do
 - with addr $ \ ptr_addr -> withLock $ do
 - throwNoSuchThingIfNull "Network.BSD.getHostByAddr" "no such host entry"
@@ -967,51 +398,14 @@ index 8d38dab..0000000
 -
 -foreign import CALLCONV safe "gethostbyaddr"
 -   c_gethostbyaddr :: Ptr HostAddress -> CInt -> CInt -> IO (Ptr HostEntry)
--
--#if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
--getHostEntry :: IO HostEntry
--getHostEntry = withLock $ do
-- throwNoSuchThingIfNull "Network.BSD.getHostEntry" "unable to retrieve host entry"
--   $ c_gethostent
-- >>= peek
--
--foreign import ccall unsafe "gethostent" c_gethostent :: IO (Ptr HostEntry)
--
--setHostEntry :: Bool -> IO ()
--setHostEntry flg = withLock $ c_sethostent (fromBool flg)
--
--foreign import ccall unsafe "sethostent" c_sethostent :: CInt -> IO ()
--
--endHostEntry :: IO ()
--endHostEntry = withLock $ c_endhostent
--
--foreign import ccall unsafe "endhostent" c_endhostent :: IO ()
--
--getHostEntries :: Bool -> IO [HostEntry]
--getHostEntries stayOpen = do
--  setHostEntry stayOpen
--  getEntries (getHostEntry) (endHostEntry)
--#endif
--
---- ---------------------------------------------------------------------------
---- Accessing network information
--
---- Same set of access functions as for accessing host,protocol and
---- service system info, this time for the types of networks supported.
--
---- network addresses are represented in host byte order.
--type NetworkAddr = CULong
--
--type NetworkName = String
--
--data NetworkEntry =
--  NetworkEntry {
--     networkName        :: NetworkName,   -- official name
--     networkAliases     :: [NetworkName], -- aliases
--     networkFamily      :: Family,         -- type
--     networkAddress     :: NetworkAddr
--   } deriving (Read, Show, Typeable)
--
++getHostByAddr family addr = error "getHostByAddr: Not implemented yet."
+ 
+ #if defined(HAVE_GETHOSTENT) && !defined(mingw32_HOST_OS)
+ getHostEntry :: IO HostEntry
+@@ -442,69 +296,26 @@ data NetworkEntry =
+      networkAddress     :: NetworkAddr
+    } deriving (Read, Show, Typeable)
+ 
 -instance Storable NetworkEntry where
 -   sizeOf    _ = #const sizeof(struct hostent)
 -   alignment _ = alignment (undefined :: CInt) -- ???
@@ -1033,9 +427,9 @@ index 8d38dab..0000000
 -
 -   poke = throwUnsupportedOperationPoke "NetworkEntry"
 -
--
--#if !defined(mingw32_HOST_OS)
--getNetworkByName :: NetworkName -> IO NetworkEntry
+ 
+ #if !defined(mingw32_HOST_OS)
+ getNetworkByName :: NetworkName -> IO NetworkEntry
 -getNetworkByName name = withLock $ do
 - withCString name $ \ name_cstr -> do
 -  throwNoSuchThingIfNull "Network.BSD.getNetworkByName" "no such network entry"
@@ -1044,8 +438,9 @@ index 8d38dab..0000000
 -
 -foreign import ccall unsafe "getnetbyname"
 -   c_getnetbyname  :: CString -> IO (Ptr NetworkEntry)
--
--getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
++getNetworkByName name = error "getNetworkByName: Not implemented yet."
+ 
+ getNetworkByAddr :: NetworkAddr -> Family -> IO NetworkEntry
 -getNetworkByAddr addr family = withLock $ do
 - throwNoSuchThingIfNull "Network.BSD.getNetworkByAddr" "no such network entry"
 -   $ c_getnetbyaddr addr (packFamily family)
@@ -1053,70 +448,39 @@ index 8d38dab..0000000
 -
 -foreign import ccall unsafe "getnetbyaddr"
 -   c_getnetbyaddr  :: NetworkAddr -> CInt -> IO (Ptr NetworkEntry)
--
--getNetworkEntry :: IO NetworkEntry
++getNetworkByAddr addr family = error "getNetworkByAddr: Not implemented yet."
+ 
+ getNetworkEntry :: IO NetworkEntry
 -getNetworkEntry = withLock $ do
 - throwNoSuchThingIfNull "Network.BSD.getNetworkEntry" "no more network entries"
 -          $ c_getnetent
 - >>= peek
 -
 -foreign import ccall unsafe "getnetent" c_getnetent :: IO (Ptr NetworkEntry)
--
---- | Open the network name database. The parameter specifies
---- whether a connection is maintained open between various
---- networkEntry calls
--setNetworkEntry :: Bool -> IO ()
++getNetworkEntry = error "getNetworkByEntry: Not implemented yet."
+ 
+ -- | Open the network name database. The parameter specifies
+ -- whether a connection is maintained open between various
+ -- networkEntry calls
+ setNetworkEntry :: Bool -> IO ()
 -setNetworkEntry flg = withLock $ c_setnetent (fromBool flg)
 -
 -foreign import ccall unsafe "setnetent" c_setnetent :: CInt -> IO ()
--
---- | Close the connection to the network name database.
--endNetworkEntry :: IO ()
++setNetworkEntry flg = error "setNetworkEntry: Not implemented yet."
+ 
+ -- | Close the connection to the network name database.
+ endNetworkEntry :: IO ()
 -endNetworkEntry = withLock $ c_endnetent
 -
 -foreign import ccall unsafe "endnetent" c_endnetent :: IO ()
--
---- | Get the list of network entries.
--getNetworkEntries :: Bool -> IO [NetworkEntry]
--getNetworkEntries stayOpen = do
--  setNetworkEntry stayOpen
--  getEntries (getNetworkEntry) (endNetworkEntry)
--#endif
--
---- ---------------------------------------------------------------------------
---- Interface names
--
--#if defined(HAVE_IF_NAMETOINDEX)
--
---- returns the index of the network interface corresponding to the name ifname.
--ifNameToIndex :: String -> IO (Maybe Int)
--ifNameToIndex ifname = do
--  index <- withCString ifname c_if_nametoindex
--  -- On failure zero is returned. We'll return Nothing.
--  return $ if index == 0 then Nothing else Just $ fromIntegral index
--
--foreign import CALLCONV safe "if_nametoindex"
--   c_if_nametoindex :: CString -> IO CUInt
--
--#endif
--
--
---- Mutex for name service lockdown
--
--{-# NOINLINE lock #-}
--lock :: MVar ()
--lock = unsafePerformIO $ withSocketsDo $ newMVar ()
--
--withLock :: IO a -> IO a
--withLock act = withMVar lock (\_ -> act)
--
---- ---------------------------------------------------------------------------
---- Miscellaneous Functions
--
---- | Calling getHostName returns the standard host name for the current
---- processor, as set at boot time.
--
--getHostName :: IO HostName
++endNetworkEntry = error "endNetworkEntry: Not implemented yet."
+ 
+ -- | Get the list of network entries.
+ getNetworkEntries :: Bool -> IO [NetworkEntry]
+@@ -547,14 +358,7 @@ withLock act = withMVar lock (\_ -> act)
+ -- processor, as set at boot time.
+ 
+ getHostName :: IO HostName
 -getHostName = do
 -  let size = 256
 -  allocaArray0 size $ \ cstr -> do
@@ -1125,268 +489,52 @@ index 8d38dab..0000000
 -
 -foreign import CALLCONV unsafe "gethostname"
 -   c_gethostname :: CString -> CSize -> IO CInt
--
---- Helper function used by the exported functions that provides a
---- Haskellised view of the enumerator functions:
--
--getEntries :: IO a  -- read
--           -> IO () -- at end
--           -> IO [a]
--getEntries getOne atEnd = loop
--  where
--    loop = do
--      vv <- E.catch (liftM Just getOne)
--            (\ e -> let _types = e :: IOException in return Nothing)
--      case vv of
--        Nothing -> return []
--        Just v  -> loop >>= \ vs -> atEnd >> return (v:vs)
--
--
--throwNoSuchThingIfNull :: String -> String -> IO (Ptr a) -> IO (Ptr a)
--throwNoSuchThingIfNull loc desc act = do
--  ptr <- act
--  if (ptr == nullPtr)
--   then ioError (ioeSetErrorString (mkIOError NoSuchThing loc Nothing Nothing) desc)
--   else return ptr
--
--throwUnsupportedOperationPoke :: String -> Ptr a -> a -> IO ()
--throwUnsupportedOperationPoke typ _ _ =
--  ioError $ ioeSetErrorString ioe "Operation not implemented"
--  where
--    ioe = mkIOError UnsupportedOperation
--                    ("Network.BSD: instance Storable " ++ typ ++ ": poke")
--                    Nothing
--                    Nothing
-diff --git a/Network/Socket.hs b/Network/Socket.hs
-new file mode 100644
-index 0000000..01bed0d
---- /dev/null
++getHostName = error "getHostName: Not implemented yet."
+ 
+ -- Helper function used by the exported functions that provides a
+ -- Haskellised view of the enumerator functions:
+diff --git a/Network/Socket.hsc b/Network/Socket.hs
+similarity index 71%
+rename from Network/Socket.hsc
+rename to Network/Socket.hs
+index 6a1ce6a..01bed0d 100644
+--- a/Network/Socket.hsc
 +++ b/Network/Socket.hs
-@@ -0,0 +1,1491 @@
+@@ -1,4 +1,4 @@
+-{-# LANGUAGE CPP, ScopedTypeVariables #-}
 +{-# LANGUAGE CPP, ScopedTypeVariables, MultiWayIf #-}
-+{-# OPTIONS_GHC -fno-warn-orphans #-}
-+-----------------------------------------------------------------------------
-+-- |
-+-- Module      :  Network.Socket
-+-- Copyright   :  (c) The University of Glasgow 2001
-+-- License     :  BSD-style (see the file libraries/network/LICENSE)
-+--
-+-- Maintainer  :  libraries@haskell.org
-+-- Stability   :  provisional
-+-- Portability :  portable
-+--
-+-- The "Network.Socket" module is for when you want full control over
-+-- sockets.  Essentially the entire C socket API is exposed through
-+-- this module; in general the operations follow the behaviour of the C
-+-- functions of the same name (consult your favourite Unix networking book).
-+--
-+-- A higher level interface to networking operations is provided
-+-- through the module "Network".
-+--
-+-----------------------------------------------------------------------------
-+
-+#include "HsNet.h"
-+
-+-- In order to process this file, you need to have CALLCONV defined.
-+
-+module Network.Socket
-+    (
-+    -- * Types
-+      Socket(..)
-+    , Family(..)
-+    , isSupportedFamily
-+    , SocketType(..)
-+    , isSupportedSocketType
-+    , SockAddr(..)
-+    , isSupportedSockAddr
-+    , SocketStatus(..)
-+    , HostAddress
-+    , hostAddressToTuple
-+    , tupleToHostAddress
-+#if defined(IPV6_SOCKET_SUPPORT)
-+    , HostAddress6
-+    , hostAddress6ToTuple
-+    , tupleToHostAddress6
-+    , FlowInfo
-+    , ScopeID
-+#endif
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ -----------------------------------------------------------------------------
+ -- |
+@@ -45,8 +45,8 @@ module Network.Socket
+     , FlowInfo
+     , ScopeID
+ #endif
+-    , htonl
+-    , ntohl
 +    -- , htonl
 +    -- , ntohl
-+    , ShutdownCmd(..)
-+    , ProtocolNumber
-+    , defaultProtocol
-+    , PortNumber(..)
-+    -- PortNumber is used non-abstractly in Network.BSD.  ToDo: remove
-+    -- this use and make the type abstract.
-+
-+    -- * Address operations
-+
-+    , HostName
-+    , ServiceName
-+
-+#if defined(IPV6_SOCKET_SUPPORT)
-+    , AddrInfo(..)
-+
-+    , AddrInfoFlag(..)
-+    , addrInfoFlagImplemented
-+
-+    , defaultHints
-+
-+    , getAddrInfo
-+
-+    , NameInfoFlag(..)
-+
-+    , getNameInfo
-+#endif
-+
-+    -- * Socket operations
-+    , socket
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+    , socketPair
-+#endif
-+    , connect
-+    , bind
-+    , listen
-+    , accept
-+    , getPeerName
-+    , getSocketName
-+
-+#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
-+    -- get the credentials of our domain socket peer.
-+    , getPeerCred
-+#if defined(HAVE_GETPEEREID)
-+    , getPeerEid
-+#endif
-+#endif
-+
-+    , socketPort
-+
-+    , socketToHandle
-+
-+    -- ** Sending and receiving data
-+    -- *** Sending and receiving with String
-+    -- $sendrecv
-+    , send
-+    , sendTo
-+    , recv
-+    , recvFrom
-+    , recvLen
-+
-+    -- *** Sending and receiving with a buffer
-+    , sendBuf
-+    , recvBuf
-+    , sendBufTo
-+    , recvBufFrom
-+
-+    -- ** Misc
-+    , inet_addr
-+    , inet_ntoa
-+
-+    , shutdown
-+    , close
-+
-+    -- ** Predicates on sockets
-+    , isConnected
-+    , isBound
-+    , isListening
-+    , isReadable
-+    , isWritable
-+
-+    -- * Socket options
-+    , SocketOption(..)
-+    , isSupportedSocketOption
-+    , getSocketOption
-+    , setSocketOption
-+
-+    -- * File descriptor transmission
-+#ifdef DOMAIN_SOCKET_SUPPORT
-+    , sendFd
-+    , recvFd
-+
-+#endif
-+
-+    -- * Special constants
-+    , aNY_PORT
-+    , iNADDR_ANY
-+#if defined(IPV6_SOCKET_SUPPORT)
-+    , iN6ADDR_ANY
-+#endif
-+    , sOMAXCONN
-+    , sOL_SOCKET
-+#ifdef SCM_RIGHTS
-+    , sCM_RIGHTS
-+#endif
-+    , maxListenQueue
-+
-+    -- * Initialisation
-+    , withSocketsDo
-+
-+    -- * Very low level operations
-+    -- in case you ever want to get at the underlying file descriptor..
-+    , fdSocket
-+    , mkSocket
-+    , setNonBlockIfNeeded
-+
-+    -- * Deprecated aliases
-+    -- $deprecated-aliases
-+    , bindSocket
-+    , sClose
-+    , sIsConnected
-+    , sIsBound
-+    , sIsListening
-+    , sIsReadable
-+    , sIsWritable
-+
-+    -- * Internal
-+
-+    -- | The following are exported ONLY for use in the BSD module and
-+    -- should not be used anywhere else.
-+
-+    , packFamily
-+    , unpackFamily
-+    , packSocketType
-+    ) where
-+
-+import Data.Bits
-+import Data.Functor
-+import Data.List (foldl')
-+import Data.Maybe (isJust)
-+import Data.Word (Word8, Word32)
-+import Foreign.Ptr (Ptr, castPtr, nullPtr)
-+import Foreign.Storable (Storable(..))
-+import Foreign.C.Error
-+import Foreign.C.String (CString, withCString, withCStringLen, peekCString, peekCStringLen)
-+import Foreign.C.Types (CUInt, CChar)
-+import Foreign.C.Types (CInt(..), CSize(..))
-+import Foreign.Marshal.Alloc ( alloca, allocaBytes )
-+import Foreign.Marshal.Array ( peekArray )
-+import Foreign.Marshal.Utils ( maybeWith, with )
-+
-+import System.IO
-+import Control.Monad (liftM, when)
-+
-+import Control.Concurrent.MVar
-+import Data.Typeable
-+import System.IO.Error
-+
+     , ShutdownCmd(..)
+     , ProtocolNumber
+     , defaultProtocol
+@@ -204,10 +204,10 @@ import Control.Concurrent.MVar
+ import Data.Typeable
+ import System.IO.Error
+ 
+-import GHC.Conc (threadWaitRead, threadWaitWrite)
+-##if MIN_VERSION_base(4,3,1)
 +import GHC.Conc (threadWaitRead, threadWaitWrite, threadWaitConnect, threadWaitAccept)
 +#if MIN_VERSION_base(4,3,1)
-+import GHC.Conc (closeFdWith)
+ import GHC.Conc (closeFdWith)
+-##endif
 +#endif
-+# if defined(mingw32_HOST_OS)
-+import qualified Control.Exception as E
-+import GHC.Conc (asyncDoProc)
-+import GHC.IO.FD (FD(..), readRawBufferPtr, writeRawBufferPtr)
-+import Foreign (FunPtr)
-+# endif
-+# if defined(darwin_HOST_OS)
-+import Data.List (delete)
-+# endif
-+import qualified GHC.IO.Device
-+import GHC.IO.Handle.FD
-+import GHC.IO.Exception
-+import GHC.IO
-+import qualified System.Posix.Internals
+ # if defined(mingw32_HOST_OS)
+ import qualified Control.Exception as E
+ import GHC.Conc (asyncDoProc)
+@@ -222,6 +222,15 @@ import GHC.IO.Handle.FD
+ import GHC.IO.Exception
+ import GHC.IO
+ import qualified System.Posix.Internals
 +#if ((ETA_VERSION == 9) && (ETA_BUILD_NUMBER >= 2)) || (ETA_VERSION > 9)
 +import GHC.IO.FD
 +import System.Posix.Types     (Channel)
@@ -1396,1714 +544,101 @@ index 0000000..01bed0d
 +import Java.Array
 +import Data.Maybe
 +#endif
-+
-+import Network.Socket.Internal
-+import Network.Socket.Types
-+
-+import Prelude -- Silence AMP warnings
-+
-+-- | Either a host name e.g., @\"haskell.org\"@ or a numeric host
-+-- address string consisting of a dotted decimal IPv4 address or an
-+-- IPv6 address e.g., @\"192.168.0.1\"@.
-+type HostName       = String
-+type ServiceName    = String
-+
-+-- ----------------------------------------------------------------------------
-+-- On Windows, our sockets are not put in non-blocking mode (non-blocking
-+-- is not supported for regular file descriptors on Windows, and it would
-+-- be a pain to support it only for sockets).  So there are two cases:
-+--
-+--  - the threaded RTS uses safe calls for socket operations to get
-+--    non-blocking I/O, just like the rest of the I/O library
-+--
-+--  - with the non-threaded RTS, only some operations on sockets will be
-+--    non-blocking.  Reads and writes go through the normal async I/O
-+--    system.  accept() uses asyncDoProc so is non-blocking.  A handful
-+--    of others (recvFrom, sendFd, recvFd) will block all threads - if this
-+--    is a problem, -threaded is the workaround.
-+--
-+#define SAFE_ON_WIN safe
-+
-+-----------------------------------------------------------------------------
-+-- Socket types
-+
-+socket2FD  (MkSocket fd _ _ _ _) = do
-+  blocking <- isBlocking fd
-+  return $ FD { fdFD = FDGeneric fd, fdIsNonBlocking = not blocking }
-+
-+-- | Smart constructor for constructing a 'Socket'. It should only be
-+-- called once for every new file descriptor. The caller must make
-+-- sure that the socket is in non-blocking mode. See
-+-- 'setNonBlockIfNeeded'.
-+mkSocket :: Channel
-+         -> Family
-+         -> SocketType
-+         -> ProtocolNumber
-+         -> SocketStatus
-+         -> IO Socket
-+mkSocket fd fam sType pNum stat = do
-+   mStat <- newMVar stat
-+   withSocketsDo $ return ()
-+   return (MkSocket fd fam sType pNum mStat)
-+
-+
-+fdSocket :: Socket -> Channel
-+fdSocket (MkSocket fd _ _ _ _) = fd
-+
-+-- | This is the default protocol for a given service.
-+defaultProtocol :: ProtocolNumber
-+defaultProtocol = 0
-+
-+-----------------------------------------------------------------------------
-+-- SockAddr
-+
-+instance Show SockAddr where
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+  showsPrec _ (SockAddrUnix str) = showString str
-+#endif
-+  showsPrec _ (SockAddrInet port ha)
-+   = showString (unsafePerformIO (inet_ntoa ha))
-+   . showString ":"
-+   . shows port
-+#if defined(IPV6_SOCKET_SUPPORT)
-+  showsPrec _ addr@(SockAddrInet6 port _ _ _)
-+   = showChar '['
-+   . showString (unsafePerformIO $
-+                 fst `liftM` getNameInfo [NI_NUMERICHOST] True False addr >>=
-+                 maybe (fail "showsPrec: impossible internal error") return)
-+   . showString "]:"
-+   . shows port
-+#endif
-+#if defined(CAN_SOCKET_SUPPORT)
-+  showsPrec _ (SockAddrCan ifidx) = shows ifidx
-+#endif
-+
-+-----------------------------------------------------------------------------
-+-- Connection Functions
-+
-+-- In the following connection and binding primitives.  The names of
-+-- the equivalent C functions have been preserved where possible. It
-+-- should be noted that some of these names used in the C library,
-+-- \tr{bind} in particular, have a different meaning to many Haskell
-+-- programmers and have thus been renamed by appending the prefix
-+-- Socket.
-+
-+-- | Create a new socket using the given address family, socket type
-+-- and protocol number.  The address family is usually 'AF_INET',
-+-- 'AF_INET6', or 'AF_UNIX'.  The socket type is usually 'Stream' or
-+-- 'Datagram'.  The protocol number is usually 'defaultProtocol'.
-+-- If 'AF_INET6' is used and the socket type is 'Stream' or 'Datagram',
-+-- the 'IPv6Only' socket option is set to 0 so that both IPv4 and IPv6
-+-- can be handled with one socket.
-+--
-+-- >>> let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
-+-- >>> addr:_ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "5000")
-+-- >>> sock@(MkSocket _ fam stype _ _) <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
-+-- >>> fam
-+-- AF_INET
-+-- >>> stype
-+-- Stream
-+-- >>> bind sock (addrAddress addr)
-+-- >>> getSocketName sock
-+-- 127.0.0.1:5000
-+socket :: Family         -- Family Name (usually AF_INET)
-+       -> SocketType     -- Socket Type (usually Stream)
-+       -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)
-+       -> IO Socket      -- Unconnected Socket
-+socket family stype protocol = do
-+    c_stype <- packSocketTypeOrThrow "socket" stype
-+    fd      <- c_socket (packFamily family) c_stype protocol
-+    setNonBlockIfNeeded fd
-+    socket_status <- newMVar NotConnected
-+    withSocketsDo $ return ()
-+    let sock = MkSocket fd family stype protocol socket_status
-+#if HAVE_DECL_IPV6_V6ONLY
-+    -- The default value of the IPv6Only option is platform specific,
-+    -- so we explicitly set it to 0 to provide a common default.
-+# if defined(mingw32_HOST_OS)
-+    -- The IPv6Only option is only supported on Windows Vista and later,
-+    -- so trying to change it might throw an error.
-+    when (family == AF_INET6 && (stype == Stream || stype == Datagram)) $
-+      E.catch (setSocketOption sock IPv6Only 0) $ (\(_ :: E.IOException) -> return ())
-+# else
-+    when (family == AF_INET6 && (stype == Stream || stype == Datagram)) $
-+      setSocketOption sock IPv6Only 0 `onException` close sock
-+# endif
-+#endif
-+    return sock
-+
-+-- | Build a pair of connected socket objects using the given address
-+-- family, socket type, and protocol number.  Address family, socket
-+-- type, and protocol number are as for the 'socket' function above.
-+-- Availability: Unix.
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+socketPair :: Family              -- Family Name (usually AF_INET or AF_INET6)
-+           -> SocketType          -- Socket Type (usually Stream)
-+           -> ProtocolNumber      -- Protocol Number
-+           -> IO (Socket, Socket) -- unnamed and connected.
-+socketPair family stype protocol = do
-+    allocaBytes (2 * sizeOf (1 :: CInt)) $ \ fdArr -> do
-+    c_stype <- packSocketTypeOrThrow "socketPair" stype
-+    _rc <- throwSocketErrorIfMinus1Retry "Network.Socket.socketpair" $
-+                c_socketpair (packFamily family) c_stype protocol fdArr
-+    [fd1,fd2] <- peekArray 2 fdArr
-+    s1 <- mkNonBlockingSocket fd1
-+    s2 <- mkNonBlockingSocket fd2
-+    return (s1,s2)
-+  where
-+    mkNonBlockingSocket fd = do
-+       setNonBlockIfNeeded fd
-+       stat <- newMVar Connected
-+       withSocketsDo $ return ()
-+       return (MkSocket fd family stype protocol stat)
-+
-+foreign import ccall unsafe "socketpair"
-+  c_socketpair :: CInt -> CInt -> CInt -> Ptr CInt -> IO CInt
-+#endif
-+
-+-- | Set the socket to nonblocking, if applicable to this platform.
-+--
-+-- Depending on the platform this is required when using sockets from file
-+-- descriptors that are passed in through 'recvFd' or other means.
-+setNonBlockIfNeeded :: Channel -> IO ()
-+setNonBlockIfNeeded fd =
-+    System.Posix.Internals.setNonBlockingFD fd True
-+
-+-----------------------------------------------------------------------------
-+-- Binding a socket
-+
-+-- | Bind the socket to an address. The socket must not already be
-+-- bound.  The 'Family' passed to @bind@ must be the
-+-- same as that passed to 'socket'.  If the special port number
-+-- 'aNY_PORT' is passed then the system assigns the next available
-+-- use port.
-+bind :: Socket    -- Unconnected Socket
-+           -> SockAddr  -- Address to Bind to
-+           -> IO ()
-+bind (MkSocket s _family _stype _protocol socketStatus) addr = do
-+ modifyMVar_ socketStatus $ \ status -> do
-+ if status /= NotConnected
-+  then
-+   ioError $ userError $
-+     "Network.Socket.bind: can't bind to socket with non-default status."
-+  else do
-+   withSockAddr addr $ \saddr -> do
-+     _status <- c_bind s saddr
-+     return (Bound addr)
-+
-+-----------------------------------------------------------------------------
-+-- Connecting a socket
-+
-+-- | Connect to a remote socket at address.
-+connect :: Socket    -- Unconnected Socket
-+        -> SockAddr  -- Socket address stuff
-+        -> IO ()
-+connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = withSocketsDo $ do
-+ modifyMVar_ socketStatus $ \currentStatus -> do
-+ if shouldError currentStatus
-+  then
-+    ioError $ userError $
-+      errLoc ++ ": can't connect to socket with status that is not bound or default."
-+  else do
-+    withSockAddr addr $ \saddr -> do
-+
-+    let connectLoop = do
-+           connected <- c_connect s saddr
-+           unless connected $ do
-+             connectBlocked
-+             connectLoop
-+
-+        connectBlocked = threadWaitConnect s
-+
-+    connectLoop
-+    return Connected
-+ where
-+   errLoc = "Network.Socket.connect: " ++ show sock
-+   shouldError NotConnected = False
-+   shouldError (Bound _) = False
-+   shouldError _ = True
-+
-+-----------------------------------------------------------------------------
-+-- Listen
-+
-+-- | Listen for connections made to the socket.  The second argument
-+-- specifies the maximum number of queued connections and should be at
-+-- least 1; the maximum value is system-dependent (usually 5).
-+listen :: Socket  -- Connected & Bound Socket
-+       -> Int     -- Queue Length
-+       -> IO ()
-+listen (MkSocket s _family _stype _protocol socketStatus) backlog = do
-+ modifyMVar_ socketStatus $ \ status -> do
-+ if | Bound sockAddr <- status -> do
-+      withSockAddr sockAddr $ \saddr -> c_listen s saddr (fromIntegral backlog)
-+      return Listening
-+    | otherwise ->
-+      ioError $ userError $
-+        "Network.Socket.listen: can't listen on socket with non-bound status."
-+
-+-----------------------------------------------------------------------------
-+-- Accept
-+--
-+-- A call to `accept' only returns when data is available on the given
-+-- socket, unless the socket has been set to non-blocking.  It will
-+-- return a new socket which should be used to read the incoming data and
-+-- should then be closed. Using the socket returned by `accept' allows
-+-- incoming requests to be queued on the original socket.
-+
-+-- | Accept a connection.  The socket must be bound to an address and
-+-- listening for connections.  The return value is a pair @(conn,
-+-- address)@ where @conn@ is a new socket object usable to send and
-+-- receive data on the connection, and @address@ is the address bound
-+-- to the socket on the other end of the connection.
-+accept :: Socket                        -- Queue Socket
-+       -> IO (Socket,                   -- Readable Socket
-+              SockAddr)                 -- Peer details
-+
-+accept sock@(MkSocket s family stype protocol status) = do
-+ currentStatus <- readMVar status
-+ okay <- isAcceptable sock
-+ if not okay
-+   then
-+     ioError $ userError $
-+       "Network.Socket.accept: can't accept socket (" ++
-+         show (family, stype, protocol) ++ ") with status not in position to accept" ++
-+         "connections."
-+   else do
-+     new_sock <- onNothingRetry $ c_accept s
-+     addr <- newSockAddr new_sock
-+     setNonBlockIfNeeded new_sock
-+     new_status <- newMVar Connected
-+     return ((MkSocket new_sock family (toStype stype) protocol new_status), addr)
-+  where onNothingRetry io = do
-+          mResult <- io
-+          case mResult of
-+            Nothing -> threadWaitAccept s >> onNothingRetry io
-+            Just ch -> return ch
-+        toStype (ServerSocket s) = s
-+
-+-----------------------------------------------------------------------------
-+-- ** Sending and receiving data
-+
-+-- $sendrecv
-+--
-+-- Do not use the @send@ and @recv@ functions defined in this section
-+-- in new code, as they incorrectly represent binary data as a Unicode
-+-- string.  As a result, these functions are inefficient and may lead
-+-- to bugs in the program.  Instead use the @send@ and @recv@
-+-- functions defined in the "Network.Socket.ByteString" module.
-+
-+-----------------------------------------------------------------------------
-+-- sendTo & recvFrom
-+
-+-- | Send data to the socket.  The recipient can be specified
-+-- explicitly, so the socket need not be in a connected state.
-+-- Returns the number of bytes sent.  Applications are responsible for
-+-- ensuring that all data has been sent.
-+--
-+-- NOTE: blocking on Windows unless you compile with -threaded (see
-+-- GHC ticket #1129)
-+{-# WARNING sendTo "Use sendTo defined in \"Network.Socket.ByteString\"" #-}
-+sendTo :: Socket        -- (possibly) bound/connected Socket
-+       -> String        -- Data to send
-+       -> SockAddr
-+       -> IO Int        -- Number of Bytes sent
-+sendTo sock xs addr = do
-+ withCStringLen xs $ \(str, len) -> do
-+   sendBufTo sock str len addr
-+
-+-- | Send data to the socket.  The recipient can be specified
-+-- explicitly, so the socket need not be in a connected state.
-+-- Returns the number of bytes sent.  Applications are responsible for
-+-- ensuring that all data has been sent.
-+sendBufTo :: Socket            -- (possibly) bound/connected Socket
-+          -> Ptr a -> Int  -- Data to send
-+          -> SockAddr
-+          -> IO Int            -- Number of Bytes sent
-+sendBufTo sock@(MkSocket s _family _stype _protocol _status) ptr nbytes addr = do
-+ withSockAddr addr $ \p_addr -> do
-+   liftM fromIntegral $
-+     throwSocketErrorWaitWrite sock "Network.Socket.sendTo" $
-+        c_sendto s ptr (fromIntegral $ nbytes) p_addr
-+
-+-- | Receive data from the socket. The socket need not be in a
-+-- connected state. Returns @(bytes, nbytes, address)@ where @bytes@
-+-- is a @String@ of length @nbytes@ representing the data received and
-+-- @address@ is a 'SockAddr' representing the address of the sending
-+-- socket.
-+--
-+-- NOTE: blocking on Windows unless you compile with -threaded (see
-+-- GHC ticket #1129)
-+{-# WARNING recvFrom "Use recvFrom defined in \"Network.Socket.ByteString\"" #-}
-+recvFrom :: Socket -> Int -> IO (String, Int, SockAddr)
-+recvFrom sock nbytes =
-+  allocaBytes nbytes $ \ptr -> do
-+    (len, sockaddr) <- recvBufFrom sock ptr nbytes
-+    str <- peekCStringLen (ptr, len)
-+    return (str, len, sockaddr)
-+
-+-- | Receive data from the socket, writing it into buffer instead of
-+-- creating a new string.  The socket need not be in a connected
-+-- state. Returns @(nbytes, address)@ where @nbytes@ is the number of
-+-- bytes received and @address@ is a 'SockAddr' representing the
-+-- address of the sending socket.
-+--
-+-- NOTE: blocking on Windows unless you compile with -threaded (see
-+-- GHC ticket #1129)
-+recvBufFrom :: Socket -> Ptr a -> Int -> IO (Int, SockAddr)
-+recvBufFrom sock@(MkSocket s family _stype _protocol _status) ptr nbytes
-+ | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvFrom")
-+ | otherwise   = error "recvBufFrom: Not implemented yet"
-+    -- withNewSockAddr family $ \ptr_addr sz -> do
-+    --   alloca $ \ptr_len -> do
-+    --     poke ptr_len (fromIntegral sz)
-+    --     len <- throwSocketErrorWaitRead sock "Network.Socket.recvFrom" $
-+    --                c_recvfrom s ptr (fromIntegral nbytes) 0{-flags-}
-+    --                             ptr_addr ptr_len
-+    --     let len' = fromIntegral len
-+    --     if len' == 0
-+    --      then ioError (mkEOFError "Network.Socket.recvFrom")
-+    --      else do
-+    --        flg <- isConnected sock
-+    --          -- For at least one implementation (WinSock 2), recvfrom() ignores
-+    --          -- filling in the sockaddr for connected TCP sockets. Cope with
-+    --          -- this by using getPeerName instead.
-+    --        sockaddr <-
-+    --             if flg then
-+    --                getPeerName sock
-+    --             else
-+    --                peekSockAddr ptr_addr
-+    --        return (len', sockaddr)
-+
-+-----------------------------------------------------------------------------
-+-- send & recv
-+
-+-- | Send data to the socket. The socket must be connected to a remote
-+-- socket. Returns the number of bytes sent.  Applications are
-+-- responsible for ensuring that all data has been sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+{-# WARNING send "Use send defined in \"Network.Socket.ByteString\"" #-}
-+send :: Socket  -- Bound/Connected Socket
-+     -> String  -- Data to send
-+     -> IO Int  -- Number of Bytes sent
-+send sock xs = withCStringLen xs $ \(str, len) ->
-+    sendBuf sock (castPtr str) len
-+
-+-- | Send data to the socket. The socket must be connected to a remote
-+-- socket. Returns the number of bytes sent.  Applications are
-+-- responsible for ensuring that all data has been sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendBuf :: Socket     -- Bound/Connected Socket
-+        -> Ptr Word8  -- Pointer to the data to send
-+        -> Int        -- Length of the buffer
-+        -> IO Int     -- Number of Bytes sent
-+sendBuf sock@(MkSocket s _family _stype _protocol _status) str len = do
-+   fd <- socket2FD sock
-+   liftM fromIntegral $
-+-- writeRawBufferPtr is supposed to handle checking for errors, but it's broken
-+-- on x86_64 because of GHC bug #12010 so we duplicate the check here. The call
-+-- to throwSocketErrorIfMinus1Retry can be removed when no GHC version with the
-+-- bug is supported.
-+    throwSocketErrorIfMinus1Retry "Network.Socket.sendBuf" $ writeRawBufferPtr
-+      "Network.Socket.sendBuf"
-+      fd
-+      (castPtr str)
-+      0
-+      (fromIntegral len)
-+
-+-- | Receive data from the socket.  The socket must be in a connected
-+-- state. This function may return fewer bytes than specified.  If the
-+-- message is longer than the specified length, it may be discarded
-+-- depending on the type of socket.  This function may block until a
-+-- message arrives.
-+--
-+-- Considering hardware and network realities, the maximum number of
-+-- bytes to receive should be a small power of 2, e.g., 4096.
-+--
-+-- For TCP sockets, a zero length return value means the peer has
-+-- closed its half side of the connection.
-+--
-+-- Receiving data from closed socket may lead to undefined behaviour.
-+{-# WARNING recv "Use recv defined in \"Network.Socket.ByteString\"" #-}
-+recv :: Socket -> Int -> IO String
-+recv sock l = fst <$> recvLen sock l
-+
-+{-# WARNING recvLen "Use recvLen defined in \"Network.Socket.ByteString\"" #-}
-+recvLen :: Socket -> Int -> IO (String, Int)
-+recvLen sock nbytes =
-+     allocaBytes nbytes $ \ptr -> do
-+        len <- recvBuf sock ptr nbytes
-+        s <- peekCStringLen (castPtr ptr,len)
-+        return (s, len)
-+
-+-- | Receive data from the socket.  The socket must be in a connected
-+-- state. This function may return fewer bytes than specified.  If the
-+-- message is longer than the specified length, it may be discarded
-+-- depending on the type of socket.  This function may block until a
-+-- message arrives.
-+--
-+-- Considering hardware and network realities, the maximum number of
-+-- bytes to receive should be a small power of 2, e.g., 4096.
-+--
-+-- For TCP sockets, a zero length return value means the peer has
-+-- closed its half side of the connection.
-+--
-+-- Receiving data from closed socket may lead to undefined behaviour.
-+recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
-+recvBuf sock@(MkSocket s _family _stype _protocol _status) ptr nbytes
-+ | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBuf")
-+ | otherwise   = do
-+        fd <- socket2FD sock
-+        len <-
-+-- see comment in sendBuf above.
-+            throwSocketErrorIfMinus1Retry "Network.Socket.recvBuf" $
-+                readRawBufferPtr "Network.Socket.recvBuf"
-+                fd ptr 0 (fromIntegral nbytes)
-+        let len' = fromIntegral len
-+        if len' == 0
-+         then ioError (mkEOFError "Network.Socket.recvBuf")
-+         else return len'
-+
-+
-+-- ---------------------------------------------------------------------------
-+-- socketPort
-+--
-+-- The port number the given socket is currently connected to can be
-+-- determined by calling $port$, is generally only useful when bind
-+-- was given $aNY\_PORT$.
-+
-+socketPort :: Socket            -- Connected & Bound Socket
-+           -> IO PortNumber     -- Port Number of Socket
-+socketPort sock@(MkSocket _ AF_INET _ _ _) = do
-+    (SockAddrInet port _) <- getSocketName sock
-+    return port
-+#if defined(IPV6_SOCKET_SUPPORT)
-+socketPort sock@(MkSocket _ AF_INET6 _ _ _) = do
-+    (SockAddrInet6 port _ _ _) <- getSocketName sock
-+    return port
-+#endif
-+socketPort (MkSocket _ family _ _ _) =
-+    ioError $ userError $
-+      "Network.Socket.socketPort: address family '" ++ show family ++
-+      "' not supported."
-+
-+
-+-- ---------------------------------------------------------------------------
-+-- getPeerName
-+
-+-- Calling $getPeerName$ returns the address details of the machine,
-+-- other than the local one, which is connected to the socket. This is
-+-- used in programs such as FTP to determine where to send the
-+-- returning data.  The corresponding call to get the details of the
-+-- local machine is $getSocketName$.
-+
-+getPeerName   :: Socket -> IO SockAddr
-+getPeerName (MkSocket s family _ _ _) =
-+  error $ "Network.Socket.getPeerName: Not implemented yet."
-+
-+getSocketName :: Socket -> IO SockAddr
-+getSocketName (MkSocket s family _ _ _) =
-+  error $ "Network.Socket.getSocketName: Not implemented yet."
-+
-+-----------------------------------------------------------------------------
-+-- Socket Properties
-+
-+-- | Socket options for use with 'setSocketOption' and 'getSocketOption'.
-+--
-+-- The existence of a constructor does not imply that the relevant option
-+-- is supported on your system: see 'isSupportedSocketOption'
-+data SocketOption
-+    = Debug         -- ^ SO_DEBUG
-+    | ReuseAddr     -- ^ SO_REUSEADDR
-+    | Type          -- ^ SO_TYPE
-+    | SoError       -- ^ SO_ERROR
-+    | DontRoute     -- ^ SO_DONTROUTE
-+    | Broadcast     -- ^ SO_BROADCAST
-+    | SendBuffer    -- ^ SO_SNDBUF
-+    | RecvBuffer    -- ^ SO_RCVBUF
-+    | KeepAlive     -- ^ SO_KEEPALIVE
-+    | OOBInline     -- ^ SO_OOBINLINE
-+    | TimeToLive    -- ^ IP_TTL
-+    | MaxSegment    -- ^ TCP_MAXSEG
-+    | NoDelay       -- ^ TCP_NODELAY
-+    | Cork          -- ^ TCP_CORK
-+    | Linger        -- ^ SO_LINGER
-+    | ReusePort     -- ^ SO_REUSEPORT
-+    | RecvLowWater  -- ^ SO_RCVLOWAT
-+    | SendLowWater  -- ^ SO_SNDLOWAT
-+    | RecvTimeOut   -- ^ SO_RCVTIMEO
-+    | SendTimeOut   -- ^ SO_SNDTIMEO
-+    | UseLoopBack   -- ^ SO_USELOOPBACK
-+    | UserTimeout   -- ^ TCP_USER_TIMEOUT
-+    | IPv6Only      -- ^ IPV6_V6ONLY
-+    | CustomSockOpt (CInt, CInt)
-+    deriving (Show, Typeable)
-+
-+-- | Does the 'SocketOption' exist on this system?
-+isSupportedSocketOption :: SocketOption -> Bool
-+isSupportedSocketOption = isJust . packSocketOption
-+
-+-- | For a socket option, return Just (level, value) where level is the
-+-- corresponding C option level constant (e.g. SOL_SOCKET) and value is
-+-- the option constant itself (e.g. SO_DEBUG)
-+-- If either constant does not exist, return Nothing.
-+packSocketOption :: SocketOption -> Maybe SOption
-+packSocketOption so =
-+  -- The Just here is a hack to disable GHC's overlapping pattern detection:
-+  -- the problem is if all constants are present, the fallback pattern is
-+  -- redundant, but if they aren't then it isn't. Hence we introduce an
-+  -- extra pattern (Nothing) that can't possibly happen, so that the
-+  -- fallback is always (in principle) necessary.
-+  -- I feel a little bad for including this, but such are the sacrifices we
-+  -- make while working with CPP - excluding the fallback pattern correctly
-+  -- would be a serious nuisance.
-+  -- (NB: comments elsewhere in this file refer to this one)
-+  case Just so of
-+    Just ReuseAddr     -> Just sO_REUSEADDR
-+    Just Broadcast     -> Just sO_BROADCAST
-+    Just SendBuffer    -> Just sO_SNDBUF
-+    Just RecvBuffer    -> Just sO_RCVBUF
-+    Just KeepAlive     -> Just sO_KEEPALIVE
-+    Just Linger        -> Just sO_LINGER
-+    Just NoDelay       -> Just tCP_NODELAY
-+    _                  -> Nothing
-+
-+-- | Return the option level and option value if they exist,
-+-- otherwise throw an error that begins "Network.Socket." ++ the String
-+-- parameter
-+packSocketOption' :: String -> SocketOption -> IO SOption
-+packSocketOption' caller so = maybe err return (packSocketOption so)
-+ where
-+  err = ioError . userError . concat $ ["Network.Socket.", caller,
-+    ": socket option ", show so, " unsupported on this system"]
-+
-+-- | Set a socket option that expects an Int value.
-+-- There is currently no API to set e.g. the timeval socket options
-+setSocketOption :: Socket
-+                -> SocketOption -- Option Name
-+                -> Int          -- Option Value
-+                -> IO ()
-+setSocketOption (MkSocket s _ _ _ _) so v = do
-+   opt <- packSocketOption' "setSocketOption" so
-+   c_setsockopt s opt (fromIntegral v)
-+
-+-- | Get a socket option that gives an Int value.
-+-- There is currently no API to get e.g. the timeval socket options
-+getSocketOption :: Socket
-+                -> SocketOption  -- Option Name
-+                -> IO Int        -- Option Value
-+getSocketOption (MkSocket s _ _ _ _) so = do
-+   opt <- packSocketOption' "getSocketOption" so
-+   fmap fromIntegral $ c_getsockopt s opt
-+
-+#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
-+-- | Returns the processID, userID and groupID of the socket's peer.
-+--
-+-- Only available on platforms that support SO_PEERCRED or GETPEEREID(3)
-+-- on domain sockets.
-+-- GETPEEREID(3) returns userID and groupID. processID is always 0.
-+getPeerCred :: Socket -> IO (CUInt, CUInt, CUInt)
-+getPeerCred sock = do
-+#ifdef HAVE_STRUCT_UCRED
-+  let fd = fdSocket sock
-+  let sz = (#const sizeof(struct ucred))
-+  allocaBytes sz $ \ ptr_cr ->
-+   with (fromIntegral sz) $ \ ptr_sz -> do
-+     _ <- ($) throwSocketErrorIfMinus1Retry "Network.Socket.getPeerCred" $
-+       c_getsockopt fd (#const SOL_SOCKET) (#const SO_PEERCRED) ptr_cr ptr_sz
-+     pid <- (#peek struct ucred, pid) ptr_cr
-+     uid <- (#peek struct ucred, uid) ptr_cr
-+     gid <- (#peek struct ucred, gid) ptr_cr
-+     return (pid, uid, gid)
-+#else
-+  (uid,gid) <- getPeerEid sock
-+  return (0,uid,gid)
-+#endif
-+
-+#ifdef HAVE_GETPEEREID
-+-- | The getpeereid() function returns the effective user and group IDs of the
-+-- peer connected to a UNIX-domain socket
-+getPeerEid :: Socket -> IO (CUInt, CUInt)
-+getPeerEid sock = do
-+  let fd = fdSocket sock
-+  alloca $ \ ptr_uid ->
-+    alloca $ \ ptr_gid -> do
-+      throwSocketErrorIfMinus1Retry_ "Network.Socket.getPeerEid" $
-+        c_getpeereid fd ptr_uid ptr_gid
-+      uid <- peek ptr_uid
-+      gid <- peek ptr_gid
-+      return (uid, gid)
-+#endif
-+#endif
-+
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+-- sending/receiving ancillary socket data; low-level mechanism
-+-- for transmitting file descriptors, mainly.
-+sendFd :: Socket -> CInt -> IO ()
-+sendFd sock outfd = do
-+  _ <- ($) throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $
-+     c_sendFd (fdSocket sock) outfd
-+   -- Note: If Winsock supported FD-passing, thi would have been
-+   -- incorrect (since socket FDs need to be closed via closesocket().)
-+  closeFd outfd
-+
-+-- | Receive a file descriptor over a domain socket. Note that the resulting
-+-- file descriptor may have to be put into non-blocking mode in order to be
-+-- used safely. See 'setNonBlockIfNeeded'.
-+recvFd :: Socket -> IO CInt
-+recvFd sock = do
-+  theFd <- throwSocketErrorWaitRead sock "Network.Socket.recvFd" $
-+               c_recvFd (fdSocket sock)
-+  return theFd
-+
-+foreign import ccall SAFE_ON_WIN "sendFd" c_sendFd :: CInt -> CInt -> IO CInt
-+foreign import ccall SAFE_ON_WIN "recvFd" c_recvFd :: CInt -> IO CInt
-+
-+#endif
-+
-+-- ---------------------------------------------------------------------------
-+-- Utility Functions
-+
-+aNY_PORT :: PortNumber
-+aNY_PORT = 0
-+
-+-- | The IPv4 wild card address.
-+
-+iNADDR_ANY :: HostAddress
-+iNADDR_ANY = 0
-+
-+-- | Converts the from host byte order to network byte order.
-+-- foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
-+-- -- | Converts the from network byte order to host byte order.
-+-- foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
-+
-+#if defined(IPV6_SOCKET_SUPPORT)
-+-- | The IPv6 wild card address.
-+
-+iN6ADDR_ANY :: HostAddress6
-+iN6ADDR_ANY = (0, 0, 0, 0)
-+#endif
-+
-+sOMAXCONN :: Int
-+sOMAXCONN = 50
-+
-+sOL_SOCKET :: Int
-+sOL_SOCKET = 0
-+
-+#ifdef SCM_RIGHTS
-+sCM_RIGHTS :: Int
-+sCM_RIGHTS = #const SCM_RIGHTS
-+#endif
-+
-+-- | This is the value of SOMAXCONN, typically 128.
-+-- 128 is good enough for normal network servers but
-+-- is too small for high performance servers.
-+maxListenQueue :: Int
-+maxListenQueue = sOMAXCONN
-+
-+-- -----------------------------------------------------------------------------
-+
-+data ShutdownCmd
-+ = ShutdownReceive
-+ | ShutdownSend
-+ | ShutdownBoth
-+ deriving Typeable
-+
-+sdownCmdToInt :: ShutdownCmd -> CInt
-+sdownCmdToInt ShutdownReceive = 0
-+sdownCmdToInt ShutdownSend    = 1
-+sdownCmdToInt ShutdownBoth    = 2
-+
-+-- | Shut down one or both halves of the connection, depending on the
-+-- second argument to the function.  If the second argument is
-+-- 'ShutdownReceive', further receives are disallowed.  If it is
-+-- 'ShutdownSend', further sends are disallowed.  If it is
-+-- 'ShutdownBoth', further sends and receives are disallowed.
-+shutdown :: Socket -> ShutdownCmd -> IO ()
-+shutdown (MkSocket s _ _ _ _) stype = do
-+  throwSocketErrorIfMinus1Retry_ "Network.Socket.shutdown" $
-+    c_shutdown s (sdownCmdToInt stype)
-+  return ()
-+
-+-- -----------------------------------------------------------------------------
-+
-+-- | Close the socket. Sending data to or receiving data from closed socket
-+-- may lead to undefined behaviour.
-+close :: Socket -> IO ()
-+close (MkSocket s _ _ _ socketStatus) = do
-+ modifyMVar_ socketStatus $ \ status ->
-+   case status of
-+     ConvertedToHandle ->
-+         ioError (userError ("close: converted to a Handle, use hClose instead"))
-+     Closed ->
-+         return status
-+     _ -> closeFdWith closeFd s >> return Closed
-+
-+-- -----------------------------------------------------------------------------
-+
-+-- | Determines whether 'close' has been used on the 'Socket'. This
-+-- does /not/ indicate any status about the socket beyond this. If the
-+-- socket has been closed remotely, this function can still return
-+-- 'True'.
-+isConnected :: Socket -> IO Bool
-+isConnected (MkSocket _ _ _ _ status) = do
-+    value <- readMVar status
-+    return (value == Connected)
-+
-+-- -----------------------------------------------------------------------------
-+-- Socket Predicates
-+
-+isBound :: Socket -> IO Bool
-+isBound (MkSocket _ _ _ _ status) = do
-+    value <- readMVar status
-+    return $ case value of
-+      Bound _ -> True
-+      _ -> False
-+
-+isListening :: Socket -> IO Bool
-+isListening (MkSocket _ _ _  _ status) = do
-+    value <- readMVar status
-+    return (value == Listening)
-+
-+isReadable  :: Socket -> IO Bool
-+isReadable (MkSocket _ _ _ _ status) = do
-+    value <- readMVar status
-+    return (value == Listening || value == Connected)
-+
-+isWritable  :: Socket -> IO Bool
-+isWritable = isReadable -- sort of.
-+
-+isAcceptable :: Socket -> IO Bool
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+isAcceptable (MkSocket _ AF_UNIX x _ status)
-+    | x == Stream || x == SeqPacket = do
-+        value <- readMVar status
-+        return (value == Connected || value == Bound || value == Listening)
-+isAcceptable (MkSocket _ AF_UNIX _ _ _) = return False
-+#endif
-+isAcceptable (MkSocket _ _ _ _ status) = do
-+    value <- readMVar status
-+    return (value == Connected || value == Listening)
-+
-+-- -----------------------------------------------------------------------------
-+-- Internet address manipulation routines:
-+
-+inet_addr :: String -> IO HostAddress
-+inet_addr ipstr = withSocketsDo $ do
-+   had <- c_inet_addr ipstr
-+   if had == -1
-+    then ioError $ userError $
-+      "Network.Socket.inet_addr: Malformed address: " ++ ipstr
-+    else return had  -- network byte order
-+
-+inet_ntoa :: HostAddress -> IO String
-+inet_ntoa haddr = withSocketsDo $ c_inet_ntoa haddr
-+
-+-- | Turns a Socket into an 'Handle'. By default, the new handle is
-+-- unbuffered. Use 'System.IO.hSetBuffering' to change the buffering.
-+--
-+-- Note that since a 'Handle' is automatically closed by a finalizer
-+-- when it is no longer referenced, you should avoid doing any more
-+-- operations on the 'Socket' after calling 'socketToHandle'.  To
-+-- close the 'Socket' after 'socketToHandle', call 'System.IO.hClose'
-+-- on the 'Handle'.
-+
-+socketToHandle :: Socket -> IOMode -> IO Handle
-+socketToHandle s@(MkSocket fd _ _ _ socketStatus) mode = do
-+ modifyMVar socketStatus $ \ status ->
-+    if status == ConvertedToHandle
-+        then ioError (userError ("socketToHandle: already a Handle"))
-+        else do
-+    h <- fdToHandle' fd (Just GHC.IO.Device.Stream) True Nothing mode True{-bin-}
-+    hSetBuffering h NoBuffering
-+    return (ConvertedToHandle, h)
-+
-+-- | Pack a list of values into a bitmask.  The possible mappings from
-+-- value to bit-to-set are given as the first argument.  We assume
-+-- that each value can cause exactly one bit to be set; unpackBits will
-+-- break if this property is not true.
-+
-+packBits :: (Eq a, Num b, Bits b) => [(a, b)] -> [a] -> b
-+
-+packBits mapping xs = foldl' pack 0 mapping
-+    where pack acc (k, v) | k `elem` xs = acc .|. v
-+                          | otherwise   = acc
-+
-+-- | Unpack a bitmask into a list of values.
-+
-+unpackBits :: (Num b, Bits b) => [(a, b)] -> b -> [a]
-+
-+-- Be permissive and ignore unknown bit values. At least on OS X,
-+-- getaddrinfo returns an ai_flags field with bits set that have no
-+-- entry in <netdb.h>.
-+unpackBits [] _    = []
-+unpackBits ((k,v):xs) r
-+    | r .&. v /= 0 = k : unpackBits xs (r .&. complement v)
-+    | otherwise    = unpackBits xs r
-+
-+-----------------------------------------------------------------------------
-+-- Address and service lookups
-+
-+#if defined(IPV6_SOCKET_SUPPORT)
-+
-+-- | Flags that control the querying behaviour of 'getAddrInfo'.
-+--   For more information, see <https://tools.ietf.org/html/rfc3493#page-25>
-+data AddrInfoFlag =
-+    -- | The list of returned 'AddrInfo' values will
-+    --   only contain IPv4 addresses if the local system has at least
-+    --   one IPv4 interface configured, and likewise for IPv6.
-+    --   (Only some platforms support this.)
-+      AI_ADDRCONFIG
-+    -- | If 'AI_ALL' is specified, return all matching IPv6 and
-+    --   IPv4 addresses.  Otherwise, this flag has no effect.
-+    --   (Only some platforms support this.)
-+    | AI_ALL
-+    -- | The 'addrCanonName' field of the first returned
-+    --   'AddrInfo' will contain the "canonical name" of the host.
-+    | AI_CANONNAME
-+    -- | The 'HostName' argument /must/ be a numeric
-+    --   address in string form, and network name lookups will not be
-+    --   attempted.
-+    | AI_NUMERICHOST
-+    -- | The 'ServiceName' argument /must/ be a port
-+    --   number in string form, and service name lookups will not be
-+    --   attempted. (Only some platforms support this.)
-+    | AI_NUMERICSERV
-+    -- | If no 'HostName' value is provided, the network
-+    --   address in each 'SockAddr'
-+    --   will be left as a "wild card", i.e. as either 'iNADDR_ANY'
-+    --   or 'iN6ADDR_ANY'.  This is useful for server applications that
-+    --   will accept connections from any client.
-+    | AI_PASSIVE
-+    -- | If an IPv6 lookup is performed, and no IPv6
-+    --   addresses are found, IPv6-mapped IPv4 addresses will be
-+    --   returned. (Only some platforms support this.)
-+    | AI_V4MAPPED
-+    deriving (Eq, Read, Show, Typeable)
-+
-+aiFlagMapping :: [(AddrInfoFlag, CInt)]
-+
-+aiFlagMapping =
-+    [
-+#if HAVE_DECL_AI_ADDRCONFIG
-+     (AI_ADDRCONFIG, #const AI_ADDRCONFIG),
-+#else
-+     (AI_ADDRCONFIG, 0),
-+#endif
-+#if HAVE_DECL_AI_ALL
-+     (AI_ALL, #const AI_ALL),
-+#else
-+     (AI_ALL, 0),
-+#endif
-+     (AI_CANONNAME, 0),
-+     (AI_NUMERICHOST, 0),
-+#if HAVE_DECL_AI_NUMERICSERV
-+     (AI_NUMERICSERV, #const AI_NUMERICSERV),
-+#else
-+     (AI_NUMERICSERV, 0),
-+#endif
-+     (AI_PASSIVE, 0),
-+#if HAVE_DECL_AI_V4MAPPED
-+     (AI_V4MAPPED, #const AI_V4MAPPED)
-+#else
-+     (AI_V4MAPPED, 0)
-+#endif
-+    ]
-+
-+-- | Indicate whether the given 'AddrInfoFlag' will have any effect on
-+-- this system.
-+addrInfoFlagImplemented :: AddrInfoFlag -> Bool
-+addrInfoFlagImplemented f = packBits aiFlagMapping [f] /= 0
-+
-+data AddrInfo =
-+    AddrInfo {
-+        addrFlags :: [AddrInfoFlag],
-+        addrFamily :: Family,
-+        addrSocketType :: SocketType,
-+        addrProtocol :: ProtocolNumber,
-+        addrAddress :: SockAddr,
-+        addrCanonName :: Maybe String
-+        }
-+    deriving (Eq, Show, Typeable)
-+
-+-- | Flags that control the querying behaviour of 'getNameInfo'.
-+--   For more information, see <https://tools.ietf.org/html/rfc3493#page-30>
-+data NameInfoFlag =
-+    -- | Resolve a datagram-based service name.  This is
-+    --   required only for the few protocols that have different port
-+    --   numbers for their datagram-based versions than for their
-+    --   stream-based versions.
-+      NI_DGRAM
-+    -- | If the hostname cannot be looked up, an IO error is thrown.
-+    | NI_NAMEREQD
-+    -- | If a host is local, return only the hostname part of the FQDN.
-+    | NI_NOFQDN
-+    -- | The name of the host is not looked up.
-+    --   Instead, a numeric representation of the host's
-+    --   address is returned.  For an IPv4 address, this will be a
-+    --   dotted-quad string.  For IPv6, it will be colon-separated
-+    --   hexadecimal.
-+    | NI_NUMERICHOST
-+    -- | The name of the service is not
-+    --   looked up.  Instead, a numeric representation of the
-+    --   service is returned.
-+    | NI_NUMERICSERV
-+    deriving (Eq, Read, Show, Typeable)
-+
-+niFlagMapping :: [(NameInfoFlag, CInt)]
-+
-+niFlagMapping = [(NI_DGRAM, 0),
-+                 (NI_NAMEREQD, 1),
-+                 (NI_NOFQDN, 2),
-+                 (NI_NUMERICHOST, 3),
-+                 (NI_NUMERICSERV, 4)]
-+
-+-- | Default hints for address lookup with 'getAddrInfo'.  The values
-+-- of the 'addrAddress' and 'addrCanonName' fields are 'undefined',
-+-- and are never inspected by 'getAddrInfo'.
-+--
-+-- >>> addrFlags defaultHints
-+-- []
-+-- >>> addrFamily defaultHints
-+-- AF_UNSPEC
-+-- >>> addrSocketType defaultHints
-+-- NoSocketType
-+-- >>> addrProtocol defaultHints
-+-- 0
-+
-+defaultHints :: AddrInfo
-+defaultHints = AddrInfo {
-+                         addrFlags = [],
-+                         addrFamily = AF_UNSPEC,
-+                         addrSocketType = NoSocketType,
-+                         addrProtocol = defaultProtocol,
-+                         addrAddress = undefined,
-+                         addrCanonName = undefined
-+                        }
-+
-+-- | Resolve a host or service name to one or more addresses.
-+-- The 'AddrInfo' values that this function returns contain 'SockAddr'
-+-- values that you can pass directly to 'connect' or
-+-- 'bind'.
-+--
-+-- This function is protocol independent.  It can return both IPv4 and
-+-- IPv6 address information.
-+--
-+-- The 'AddrInfo' argument specifies the preferred query behaviour,
-+-- socket options, or protocol.  You can override these conveniently
-+-- using Haskell's record update syntax on 'defaultHints', for example
-+-- as follows:
-+--
-+-- >>> let hints = defaultHints { addrFlags = [AI_NUMERICHOST], addrSocketType = Stream }
-+--
-+-- You must provide a 'Just' value for at least one of the 'HostName'
-+-- or 'ServiceName' arguments.  'HostName' can be either a numeric
-+-- network address (dotted quad for IPv4, colon-separated hex for
-+-- IPv6) or a hostname.  In the latter case, its addresses will be
-+-- looked up unless 'AI_NUMERICHOST' is specified as a hint.  If you
-+-- do not provide a 'HostName' value /and/ do not set 'AI_PASSIVE' as
-+-- a hint, network addresses in the result will contain the address of
-+-- the loopback interface.
-+--
-+-- If the query fails, this function throws an IO exception instead of
-+-- returning an empty list.  Otherwise, it returns a non-empty list
-+-- of 'AddrInfo' values.
-+--
-+-- There are several reasons why a query might result in several
-+-- values.  For example, the queried-for host could be multihomed, or
-+-- the service might be available via several protocols.
-+--
-+-- Note: the order of arguments is slightly different to that defined
-+-- for @getaddrinfo@ in RFC 2553.  The 'AddrInfo' parameter comes first
-+-- to make partial application easier.
-+--
-+-- >>> addr:_ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "http")
-+-- >>> addrAddress addr
-+-- 127.0.0.1:80
-+
-+getAddrInfo :: Maybe AddrInfo -- ^ preferred socket type or protocol
-+            -> Maybe HostName -- ^ host name to look up
-+            -> Maybe ServiceName -- ^ service name to look up
-+            -> IO [AddrInfo] -- ^ resolved addresses, with "best" first
-+
-+getAddrInfo mHints node service = withSocketsDo $ do
-+  addresses <- c_getaddrinfo (fromMaybe "0.0.0.0" node)
-+  return $ map toAddrInfo $ filter filterFun $ fromJava addresses
-+  where toAddrInfo inetAddr = defaultHints {
-+          addrAddress    = SockAddrInet port (inetAddrInt inetAddr),
-+          addrSocketType = maybe (addrSocketType defaultHints) addrSocketType mHints,
-+          addrFamily     = if isIPv6 inetAddr then AF_INET6 else AF_INET
-+          }
-+        filterFun  =
-+          case addrFamilySelect of
-+            AF_INET  -> not . isIPv6
-+            AF_INET6 -> isIPv6
-+            _        -> const True
-+        addrFamilySelect = maybe (addrFamily defaultHints) addrFamily mHints
-+        port
-+          | Just port' <- service
-+          = read port'
-+          | otherwise = 0
-+
-+foreign import CALLCONV unsafe "@static java.net.InetAddress.getAllByName"
-+  c_getaddrinfo :: String -> IO InetAddressArray
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.isIPv6"
-+  isIPv6 :: InetAddress -> Bool
-+
-+withCStringIf :: Bool -> Int -> (CSize -> CString -> IO a) -> IO a
-+withCStringIf False _ f = f 0 nullPtr
-+withCStringIf True n f = allocaBytes n (f (fromIntegral n))
-+
-+-- | Resolve an address to a host or service name.
-+-- This function is protocol independent.
-+-- The list of 'NameInfoFlag' values controls query behaviour.
-+--
-+-- If a host or service's name cannot be looked up, then the numeric
-+-- form of the address or service will be returned.
-+--
-+-- If the query fails, this function throws an IO exception.
-+--
-+-- Example:
-+-- @
-+--   (hostName, _) <- getNameInfo [] True False myAddress
-+-- @
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.inet6_ntoa"
-+  inet6_ntoa :: JIntArray -> String
-+
-+getNameInfo :: [NameInfoFlag] -- ^ flags to control lookup behaviour
-+            -> Bool -- ^ whether to look up a hostname
-+            -> Bool -- ^ whether to look up a service name
-+            -> SockAddr -- ^ the address to look up
-+            -> IO (Maybe HostName, Maybe ServiceName)
-+
-+getNameInfo _flags _doHost _doService addr =
-+  case addr of
-+    SockAddrInet6 _ _ addr _ -> do
-+      let (ip1,ip2,ip3,ip4) = addr
-+      hostName <- c_getnameinfo $ toJByteArray (concatMap word32to8 [ip1,ip2,ip3,ip4])
-+      return (Just hostName, Nothing)
-+    SockAddrInet _ addr -> do
-+      hostName <- c_getnameinfo $ toJByteArray (word32to8 addr)
-+      return (Just hostName, Nothing)
-+  where word32to8 w32 = map fromIntegral [(w32 `shiftR` 24) .&. 0xFF
-+                                         ,(w32 `shiftR` 16) .&. 0xFF
-+                                         ,(w32 `shiftR` 8)  .&. 0xFF
-+                                         ,w32 .&. 0xFF]
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.getNameInfo"
-+  c_getnameinfo :: JByteArray -> IO String
-+#endif
-+
-+mkInvalidRecvArgError :: String -> IOError
-+mkInvalidRecvArgError loc = ioeSetErrorString (mkIOError
-+                                    InvalidArgument
-+                                    loc Nothing Nothing) "non-positive length"
-+
-+mkEOFError :: String -> IOError
-+mkEOFError loc = ioeSetErrorString (mkIOError EOF loc Nothing Nothing) "end of file"
-+
-+-- ---------------------------------------------------------------------------
-+-- foreign imports from the C library
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.inet_ntoa"
-+  c_inet_ntoa :: HostAddress -> IO String
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.inet_addr"
-+  c_inet_addr :: String -> IO HostAddress
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.shutdown"
-+  c_shutdown :: Channel -> CInt -> IO CInt
-+
-+closeFd :: Channel -> IO ()
-+closeFd fd = c_close fd
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.socket"
-+  c_socket :: CInt -> CInt -> CInt -> IO Channel
-+foreign import CALLCONV unsafe "@static eta.network.Utils.bind"
-+  c_bind :: Channel -> SocketAddress -> IO CInt
-+foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.connect"
-+  c_connect :: Channel -> SocketAddress -> IO Bool
-+foreign import CALLCONV unsafe "@static eta.network.Utils.accept"
-+  c_accept :: Channel -> IO (Maybe Channel)
-+foreign import CALLCONV unsafe "@static eta.network.Utils.listen"
-+  c_listen :: Channel -> SocketAddress -> CInt -> IO CInt
-+
-+-- foreign import CALLCONV unsafe "send"
-+--   c_send :: CInt -> Ptr a -> CSize -> CInt -> IO CInt
-+foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.sendto"
-+  c_sendto :: Channel -> Ptr a -> CSize -> SocketAddress -> IO CInt
-+-- foreign import CALLCONV unsafe "recv"
-+--   c_recv :: CInt -> Ptr CChar -> CSize -> CInt -> IO CInt
-+-- foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.sendto"
-+--   c_recvfrom :: CInt -> Ptr a -> CSize -> CInt -> Ptr SockAddr -> IO CInt
-+-- foreign import CALLCONV unsafe "getpeername"
-+--   c_getpeername :: CInt -> Ptr SockAddr -> Ptr CInt -> IO CInt
-+-- foreign import CALLCONV unsafe "getsockname"
-+--   c_getsockname :: CInt -> Ptr SockAddr -> Ptr CInt -> IO CInt
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.getsockopt"
-+  c_getsockopt :: Channel -> SOption -> IO CInt
-+foreign import CALLCONV unsafe "@static eta.network.Utils.setsockopt"
-+  c_setsockopt :: Channel -> SOption -> CInt ->  IO ()
-+
-+#if defined(HAVE_GETPEEREID)
-+foreign import CALLCONV unsafe "getpeereid"
-+  c_getpeereid :: CInt -> Ptr CUInt -> Ptr CUInt -> IO CInt
-+#endif
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.isBlocking" isBlocking
-+  :: Channel -> IO Bool
-+
-+data {-# CLASS "java.net.SocketOption" #-} SOption = SOption (Object# SOption)
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_IF"
-+  iP_MULTICAST_IF :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_LOOP"
-+  iP_MULTICAST_LOOP :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_TTL"
-+  iP_MULTICAST_TTL :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.IP_TOS"
-+  iP_TOS :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_BROADCAST"
-+  sO_BROADCAST :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_KEEPALIVE"
-+  sO_KEEPALIVE :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_LINGER"
-+  sO_LINGER :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_RCVBUF"
-+  sO_RCVBUF :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_REUSEADDR"
-+  sO_REUSEADDR :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.SO_SNDBUF"
-+  sO_SNDBUF :: SOption
-+
-+foreign import java unsafe
-+  "@static @field java.net.StandardSocketOptions.TCP_NODELAY"
-+  tCP_NODELAY :: SOption
-+
-+-- ---------------------------------------------------------------------------
-+-- * Deprecated aliases
-+
-+-- $deprecated-aliases
-+--
-+-- These aliases are deprecated and should not be used in new code.
-+-- They will be removed in some future version of the package.
-+
-+{-# DEPRECATED bindSocket "use 'bind'" #-}
-+
-+-- | Deprecated alias for 'bind'.
-+bindSocket :: Socket    -- Unconnected Socket
-+           -> SockAddr  -- Address to Bind to
-+           -> IO ()
-+bindSocket = bind
-+
-+{-# DEPRECATED sClose "use 'close'" #-}
-+
-+-- | Deprecated alias for 'close'.
-+sClose :: Socket -> IO ()
-+sClose = close
-+
-+{-# DEPRECATED sIsConnected "use 'isConnected'" #-}
-+
-+-- | Deprecated alias for 'isConnected'.
-+sIsConnected :: Socket -> IO Bool
-+sIsConnected = isConnected
-+
-+{-# DEPRECATED sIsBound "use 'isBound'" #-}
-+
-+-- | Deprecated alias for 'isBound'.
-+sIsBound :: Socket -> IO Bool
-+sIsBound = isBound
-+
-+{-# DEPRECATED sIsListening "use 'isListening'" #-}
-+
-+-- | Deprecated alias for 'isListening'.
-+sIsListening :: Socket -> IO Bool
-+sIsListening = isListening
-+
-+{-# DEPRECATED sIsReadable "use 'isReadable'" #-}
-+
-+-- | Deprecated alias for 'isReadable'.
-+sIsReadable  :: Socket -> IO Bool
-+sIsReadable = isReadable
-+
-+{-# DEPRECATED sIsWritable "use 'isWritable'" #-}
-+
-+-- | Deprecated alias for 'isWritable'.
-+sIsWritable  :: Socket -> IO Bool
-+sIsWritable = isWritable
-diff --git a/Network/Socket.hsc b/Network/Socket.hsc
-deleted file mode 100644
-index 6a1ce6a..0000000
---- a/Network/Socket.hsc
-+++ /dev/null
-@@ -1,1683 +0,0 @@
--{-# LANGUAGE CPP, ScopedTypeVariables #-}
--{-# OPTIONS_GHC -fno-warn-orphans #-}
-------------------------------------------------------------------------------
---- |
---- Module      :  Network.Socket
---- Copyright   :  (c) The University of Glasgow 2001
---- License     :  BSD-style (see the file libraries/network/LICENSE)
----
---- Maintainer  :  libraries@haskell.org
---- Stability   :  provisional
---- Portability :  portable
----
---- The "Network.Socket" module is for when you want full control over
---- sockets.  Essentially the entire C socket API is exposed through
---- this module; in general the operations follow the behaviour of the C
---- functions of the same name (consult your favourite Unix networking book).
----
---- A higher level interface to networking operations is provided
---- through the module "Network".
----
-------------------------------------------------------------------------------
--
--#include "HsNet.h"
--
---- In order to process this file, you need to have CALLCONV defined.
--
--module Network.Socket
--    (
--    -- * Types
--      Socket(..)
--    , Family(..)
--    , isSupportedFamily
--    , SocketType(..)
--    , isSupportedSocketType
--    , SockAddr(..)
--    , isSupportedSockAddr
--    , SocketStatus(..)
--    , HostAddress
--    , hostAddressToTuple
--    , tupleToHostAddress
--#if defined(IPV6_SOCKET_SUPPORT)
--    , HostAddress6
--    , hostAddress6ToTuple
--    , tupleToHostAddress6
--    , FlowInfo
--    , ScopeID
--#endif
--    , htonl
--    , ntohl
--    , ShutdownCmd(..)
--    , ProtocolNumber
--    , defaultProtocol
--    , PortNumber(..)
--    -- PortNumber is used non-abstractly in Network.BSD.  ToDo: remove
--    -- this use and make the type abstract.
--
--    -- * Address operations
--
--    , HostName
--    , ServiceName
--
--#if defined(IPV6_SOCKET_SUPPORT)
--    , AddrInfo(..)
--
--    , AddrInfoFlag(..)
--    , addrInfoFlagImplemented
--
--    , defaultHints
--
--    , getAddrInfo
--
--    , NameInfoFlag(..)
--
--    , getNameInfo
--#endif
--
--    -- * Socket operations
--    , socket
--#if defined(DOMAIN_SOCKET_SUPPORT)
--    , socketPair
--#endif
--    , connect
--    , bind
--    , listen
--    , accept
--    , getPeerName
--    , getSocketName
--
--#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
--    -- get the credentials of our domain socket peer.
--    , getPeerCred
--#if defined(HAVE_GETPEEREID)
--    , getPeerEid
--#endif
--#endif
--
--    , socketPort
--
--    , socketToHandle
--
--    -- ** Sending and receiving data
--    -- *** Sending and receiving with String
--    -- $sendrecv
--    , send
--    , sendTo
--    , recv
--    , recvFrom
--    , recvLen
--
--    -- *** Sending and receiving with a buffer
--    , sendBuf
--    , recvBuf
--    , sendBufTo
--    , recvBufFrom
--
--    -- ** Misc
--    , inet_addr
--    , inet_ntoa
--
--    , shutdown
--    , close
--
--    -- ** Predicates on sockets
--    , isConnected
--    , isBound
--    , isListening
--    , isReadable
--    , isWritable
--
--    -- * Socket options
--    , SocketOption(..)
--    , isSupportedSocketOption
--    , getSocketOption
--    , setSocketOption
--
--    -- * File descriptor transmission
--#ifdef DOMAIN_SOCKET_SUPPORT
--    , sendFd
--    , recvFd
--
--#endif
--
--    -- * Special constants
--    , aNY_PORT
--    , iNADDR_ANY
--#if defined(IPV6_SOCKET_SUPPORT)
--    , iN6ADDR_ANY
--#endif
--    , sOMAXCONN
--    , sOL_SOCKET
--#ifdef SCM_RIGHTS
--    , sCM_RIGHTS
--#endif
--    , maxListenQueue
--
--    -- * Initialisation
--    , withSocketsDo
--
--    -- * Very low level operations
--    -- in case you ever want to get at the underlying file descriptor..
--    , fdSocket
--    , mkSocket
--    , setNonBlockIfNeeded
--
--    -- * Deprecated aliases
--    -- $deprecated-aliases
--    , bindSocket
--    , sClose
--    , sIsConnected
--    , sIsBound
--    , sIsListening
--    , sIsReadable
--    , sIsWritable
--
--    -- * Internal
--
--    -- | The following are exported ONLY for use in the BSD module and
--    -- should not be used anywhere else.
--
--    , packFamily
--    , unpackFamily
--    , packSocketType
--    ) where
--
--import Data.Bits
--import Data.Functor
--import Data.List (foldl')
--import Data.Maybe (isJust)
--import Data.Word (Word8, Word32)
--import Foreign.Ptr (Ptr, castPtr, nullPtr)
--import Foreign.Storable (Storable(..))
--import Foreign.C.Error
--import Foreign.C.String (CString, withCString, withCStringLen, peekCString, peekCStringLen)
--import Foreign.C.Types (CUInt, CChar)
--import Foreign.C.Types (CInt(..), CSize(..))
--import Foreign.Marshal.Alloc ( alloca, allocaBytes )
--import Foreign.Marshal.Array ( peekArray )
--import Foreign.Marshal.Utils ( maybeWith, with )
--
--import System.IO
--import Control.Monad (liftM, when)
--
--import Control.Concurrent.MVar
--import Data.Typeable
--import System.IO.Error
--
--import GHC.Conc (threadWaitRead, threadWaitWrite)
--##if MIN_VERSION_base(4,3,1)
--import GHC.Conc (closeFdWith)
--##endif
--# if defined(mingw32_HOST_OS)
--import qualified Control.Exception as E
--import GHC.Conc (asyncDoProc)
--import GHC.IO.FD (FD(..), readRawBufferPtr, writeRawBufferPtr)
--import Foreign (FunPtr)
--# endif
--# if defined(darwin_HOST_OS)
--import Data.List (delete)
--# endif
--import qualified GHC.IO.Device
--import GHC.IO.Handle.FD
--import GHC.IO.Exception
--import GHC.IO
--import qualified System.Posix.Internals
--
--import Network.Socket.Internal
--import Network.Socket.Types
--
--import Prelude -- Silence AMP warnings
--
---- | Either a host name e.g., @\"haskell.org\"@ or a numeric host
---- address string consisting of a dotted decimal IPv4 address or an
---- IPv6 address e.g., @\"192.168.0.1\"@.
--type HostName       = String
--type ServiceName    = String
--
---- ----------------------------------------------------------------------------
---- On Windows, our sockets are not put in non-blocking mode (non-blocking
---- is not supported for regular file descriptors on Windows, and it would
---- be a pain to support it only for sockets).  So there are two cases:
----
----  - the threaded RTS uses safe calls for socket operations to get
----    non-blocking I/O, just like the rest of the I/O library
----
----  - with the non-threaded RTS, only some operations on sockets will be
----    non-blocking.  Reads and writes go through the normal async I/O
----    system.  accept() uses asyncDoProc so is non-blocking.  A handful
----    of others (recvFrom, sendFd, recvFd) will block all threads - if this
----    is a problem, -threaded is the workaround.
----
+ 
+ import Network.Socket.Internal
+ import Network.Socket.Types
+@@ -248,26 +257,20 @@ type ServiceName    = String
+ --    of others (recvFrom, sendFd, recvFd) will block all threads - if this
+ --    is a problem, -threaded is the workaround.
+ --
 -##if defined(mingw32_HOST_OS)
 -##define SAFE_ON_WIN safe
 -##else
 -##define SAFE_ON_WIN unsafe
 -##endif
--
-------------------------------------------------------------------------------
---- Socket types
--
++#define SAFE_ON_WIN safe
+ 
+ -----------------------------------------------------------------------------
+ -- Socket types
+ 
 -#if defined(mingw32_HOST_OS)
 -socket2FD  (MkSocket fd _ _ _ _) =
 -  -- HACK, 1 means True
 -  FD{fdFD = fd,fdIsSocket_ = 1}
 -#endif
--
---- | Smart constructor for constructing a 'Socket'. It should only be
---- called once for every new file descriptor. The caller must make
---- sure that the socket is in non-blocking mode. See
---- 'setNonBlockIfNeeded'.
++socket2FD  (MkSocket fd _ _ _ _) = do
++  blocking <- isBlocking fd
++  return $ FD { fdFD = FDGeneric fd, fdIsNonBlocking = not blocking }
+ 
+ -- | Smart constructor for constructing a 'Socket'. It should only be
+ -- called once for every new file descriptor. The caller must make
+ -- sure that the socket is in non-blocking mode. See
+ -- 'setNonBlockIfNeeded'.
 -mkSocket :: CInt
--         -> Family
--         -> SocketType
--         -> ProtocolNumber
--         -> SocketStatus
--         -> IO Socket
--mkSocket fd fam sType pNum stat = do
--   mStat <- newMVar stat
--   withSocketsDo $ return ()
--   return (MkSocket fd fam sType pNum mStat)
--
--
++mkSocket :: Channel
+          -> Family
+          -> SocketType
+          -> ProtocolNumber
+@@ -279,7 +282,7 @@ mkSocket fd fam sType pNum stat = do
+    return (MkSocket fd fam sType pNum mStat)
+ 
+ 
 -fdSocket :: Socket -> CInt
--fdSocket (MkSocket fd _ _ _ _) = fd
--
---- | This is the default protocol for a given service.
--defaultProtocol :: ProtocolNumber
--defaultProtocol = 0
--
-------------------------------------------------------------------------------
---- SockAddr
--
--instance Show SockAddr where
--#if defined(DOMAIN_SOCKET_SUPPORT)
--  showsPrec _ (SockAddrUnix str) = showString str
--#endif
--  showsPrec _ (SockAddrInet port ha)
--   = showString (unsafePerformIO (inet_ntoa ha))
--   . showString ":"
--   . shows port
--#if defined(IPV6_SOCKET_SUPPORT)
--  showsPrec _ addr@(SockAddrInet6 port _ _ _)
--   = showChar '['
--   . showString (unsafePerformIO $
--                 fst `liftM` getNameInfo [NI_NUMERICHOST] True False addr >>=
--                 maybe (fail "showsPrec: impossible internal error") return)
--   . showString "]:"
--   . shows port
--#endif
--#if defined(CAN_SOCKET_SUPPORT)
--  showsPrec _ (SockAddrCan ifidx) = shows ifidx
--#endif
--
-------------------------------------------------------------------------------
---- Connection Functions
--
---- In the following connection and binding primitives.  The names of
---- the equivalent C functions have been preserved where possible. It
---- should be noted that some of these names used in the C library,
---- \tr{bind} in particular, have a different meaning to many Haskell
---- programmers and have thus been renamed by appending the prefix
---- Socket.
--
---- | Create a new socket using the given address family, socket type
---- and protocol number.  The address family is usually 'AF_INET',
---- 'AF_INET6', or 'AF_UNIX'.  The socket type is usually 'Stream' or
---- 'Datagram'.  The protocol number is usually 'defaultProtocol'.
---- If 'AF_INET6' is used and the socket type is 'Stream' or 'Datagram',
---- the 'IPv6Only' socket option is set to 0 so that both IPv4 and IPv6
---- can be handled with one socket.
----
---- >>> let hints = defaultHints { addrFlags = [AI_NUMERICHOST, AI_NUMERICSERV], addrSocketType = Stream }
---- >>> addr:_ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "5000")
---- >>> sock@(MkSocket _ fam stype _ _) <- socket (addrFamily addr) (addrSocketType addr) (addrProtocol addr)
---- >>> fam
---- AF_INET
---- >>> stype
---- Stream
---- >>> bind sock (addrAddress addr)
---- >>> getSocketName sock
---- 127.0.0.1:5000
--socket :: Family         -- Family Name (usually AF_INET)
--       -> SocketType     -- Socket Type (usually Stream)
--       -> ProtocolNumber -- Protocol Number (getProtocolByName to find value)
--       -> IO Socket      -- Unconnected Socket
--socket family stype protocol = do
--    c_stype <- packSocketTypeOrThrow "socket" stype
++fdSocket :: Socket -> Channel
+ fdSocket (MkSocket fd _ _ _ _) = fd
+ 
+ -- | This is the default protocol for a given service.
+@@ -344,8 +347,7 @@ socket :: Family         -- Family Name (usually AF_INET)
+        -> IO Socket      -- Unconnected Socket
+ socket family stype protocol = do
+     c_stype <- packSocketTypeOrThrow "socket" stype
 -    fd <- throwSocketErrorIfMinus1Retry "Network.Socket.socket" $
 -                c_socket (packFamily family) c_stype protocol
--    setNonBlockIfNeeded fd
--    socket_status <- newMVar NotConnected
--    withSocketsDo $ return ()
--    let sock = MkSocket fd family stype protocol socket_status
--#if HAVE_DECL_IPV6_V6ONLY
--    -- The default value of the IPv6Only option is platform specific,
--    -- so we explicitly set it to 0 to provide a common default.
--# if defined(mingw32_HOST_OS)
--    -- The IPv6Only option is only supported on Windows Vista and later,
--    -- so trying to change it might throw an error.
--    when (family == AF_INET6 && (stype == Stream || stype == Datagram)) $
--      E.catch (setSocketOption sock IPv6Only 0) $ (\(_ :: E.IOException) -> return ())
--# else
--    when (family == AF_INET6 && (stype == Stream || stype == Datagram)) $
--      setSocketOption sock IPv6Only 0 `onException` close sock
--# endif
--#endif
--    return sock
--
---- | Build a pair of connected socket objects using the given address
---- family, socket type, and protocol number.  Address family, socket
---- type, and protocol number are as for the 'socket' function above.
---- Availability: Unix.
--#if defined(DOMAIN_SOCKET_SUPPORT)
--socketPair :: Family              -- Family Name (usually AF_INET or AF_INET6)
--           -> SocketType          -- Socket Type (usually Stream)
--           -> ProtocolNumber      -- Protocol Number
--           -> IO (Socket, Socket) -- unnamed and connected.
--socketPair family stype protocol = do
--    allocaBytes (2 * sizeOf (1 :: CInt)) $ \ fdArr -> do
--    c_stype <- packSocketTypeOrThrow "socketPair" stype
--    _rc <- throwSocketErrorIfMinus1Retry "Network.Socket.socketpair" $
--                c_socketpair (packFamily family) c_stype protocol fdArr
--    [fd1,fd2] <- peekArray 2 fdArr
--    s1 <- mkNonBlockingSocket fd1
--    s2 <- mkNonBlockingSocket fd2
--    return (s1,s2)
--  where
--    mkNonBlockingSocket fd = do
--       setNonBlockIfNeeded fd
--       stat <- newMVar Connected
--       withSocketsDo $ return ()
--       return (MkSocket fd family stype protocol stat)
--
--foreign import ccall unsafe "socketpair"
--  c_socketpair :: CInt -> CInt -> CInt -> Ptr CInt -> IO CInt
--#endif
--
---- | Set the socket to nonblocking, if applicable to this platform.
----
---- Depending on the platform this is required when using sockets from file
---- descriptors that are passed in through 'recvFd' or other means.
++    fd      <- c_socket (packFamily family) c_stype protocol
+     setNonBlockIfNeeded fd
+     socket_status <- newMVar NotConnected
+     withSocketsDo $ return ()
+@@ -398,7 +400,7 @@ foreign import ccall unsafe "socketpair"
+ --
+ -- Depending on the platform this is required when using sockets from file
+ -- descriptors that are passed in through 'recvFd' or other means.
 -setNonBlockIfNeeded :: CInt -> IO ()
--setNonBlockIfNeeded fd =
--    System.Posix.Internals.setNonBlockingFD fd True
--
-------------------------------------------------------------------------------
---- Binding a socket
--
---- | Bind the socket to an address. The socket must not already be
---- bound.  The 'Family' passed to @bind@ must be the
---- same as that passed to 'socket'.  If the special port number
---- 'aNY_PORT' is passed then the system assigns the next available
---- use port.
--bind :: Socket    -- Unconnected Socket
--           -> SockAddr  -- Address to Bind to
--           -> IO ()
--bind (MkSocket s _family _stype _protocol socketStatus) addr = do
-- modifyMVar_ socketStatus $ \ status -> do
-- if status /= NotConnected
--  then
--   ioError $ userError $
++setNonBlockIfNeeded :: Channel -> IO ()
+ setNonBlockIfNeeded fd =
+     System.Posix.Internals.setNonBlockingFD fd True
+ 
+@@ -418,12 +420,11 @@ bind (MkSocket s _family _stype _protocol socketStatus) addr = do
+  if status /= NotConnected
+   then
+    ioError $ userError $
 -     "Network.Socket.bind: can't bind to socket with status " ++ show status
--  else do
++     "Network.Socket.bind: can't bind to socket with non-default status."
+   else do
 -   withSockAddr addr $ \p_addr sz -> do
 -   _status <- throwSocketErrorIfMinus1Retry "Network.Socket.bind" $
 -     c_bind s p_addr (fromIntegral sz)
 -   return Bound
--
-------------------------------------------------------------------------------
---- Connecting a socket
--
---- | Connect to a remote socket at address.
--connect :: Socket    -- Unconnected Socket
--        -> SockAddr  -- Socket address stuff
--        -> IO ()
--connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = withSocketsDo $ do
-- modifyMVar_ socketStatus $ \currentStatus -> do
++   withSockAddr addr $ \saddr -> do
++     _status <- c_bind s saddr
++     return (Bound addr)
+ 
+ -----------------------------------------------------------------------------
+ -- Connecting a socket
+@@ -434,40 +435,28 @@ connect :: Socket    -- Unconnected Socket
+         -> IO ()
+ connect sock@(MkSocket s _family _stype _protocol socketStatus) addr = withSocketsDo $ do
+  modifyMVar_ socketStatus $ \currentStatus -> do
 - if currentStatus /= NotConnected && currentStatus /= Bound
--  then
--    ioError $ userError $
++ if shouldError currentStatus
+   then
+     ioError $ userError $
 -      errLoc ++ ": can't connect to socket with status " ++ show currentStatus
--  else do
++      errLoc ++ ": can't connect to socket with status that is not bound or default."
+   else do
 -    withSockAddr addr $ \p_addr sz -> do
--
--    let connectLoop = do
++    withSockAddr addr $ \saddr -> do
+ 
+     let connectLoop = do
 -           r <- c_connect s p_addr (fromIntegral sz)
 -           if r == -1
 -               then do
@@ -3118,30 +653,33 @@ index 6a1ce6a..0000000
 -                   throwSocketError errLoc
 -#endif
 -               else return ()
--
++           connected <- c_connect s saddr
++           unless connected $ do
++             connectBlocked
++             connectLoop
+ 
 -        connectBlocked = do
 -           threadWaitWrite (fromIntegral s)
 -           err <- getSocketOption sock SoError
 -           if (err == 0)
 -                then return ()
 -                else throwSocketErrorCode errLoc (fromIntegral err)
--
--    connectLoop
--    return Connected
-- where
--   errLoc = "Network.Socket.connect: " ++ show sock
--
-------------------------------------------------------------------------------
---- Listen
--
---- | Listen for connections made to the socket.  The second argument
---- specifies the maximum number of queued connections and should be at
---- least 1; the maximum value is system-dependent (usually 5).
--listen :: Socket  -- Connected & Bound Socket
--       -> Int     -- Queue Length
--       -> IO ()
--listen (MkSocket s _family _stype _protocol socketStatus) backlog = do
-- modifyMVar_ socketStatus $ \ status -> do
++        connectBlocked = threadWaitConnect s
+ 
+     connectLoop
+     return Connected
+  where
+    errLoc = "Network.Socket.connect: " ++ show sock
++   shouldError NotConnected = False
++   shouldError (Bound _) = False
++   shouldError _ = True
+ 
+ -----------------------------------------------------------------------------
+ -- Listen
+@@ -480,14 +469,12 @@ listen :: Socket  -- Connected & Bound Socket
+        -> IO ()
+ listen (MkSocket s _family _stype _protocol socketStatus) backlog = do
+  modifyMVar_ socketStatus $ \ status -> do
 - if status /= Bound
 -   then
 -     ioError $ userError $
@@ -3150,35 +688,24 @@ index 6a1ce6a..0000000
 -     throwSocketErrorIfMinus1Retry_ "Network.Socket.listen" $
 -       c_listen s (fromIntegral backlog)
 -     return Listening
--
-------------------------------------------------------------------------------
---- Accept
----
---- A call to `accept' only returns when data is available on the given
---- socket, unless the socket has been set to non-blocking.  It will
---- return a new socket which should be used to read the incoming data and
---- should then be closed. Using the socket returned by `accept' allows
---- incoming requests to be queued on the original socket.
--
---- | Accept a connection.  The socket must be bound to an address and
---- listening for connections.  The return value is a pair @(conn,
---- address)@ where @conn@ is a new socket object usable to send and
---- receive data on the connection, and @address@ is the address bound
---- to the socket on the other end of the connection.
--accept :: Socket                        -- Queue Socket
--       -> IO (Socket,                   -- Readable Socket
--              SockAddr)                 -- Peer details
--
--accept sock@(MkSocket s family stype protocol status) = do
-- currentStatus <- readMVar status
-- okay <- isAcceptable sock
-- if not okay
--   then
--     ioError $ userError $
--       "Network.Socket.accept: can't accept socket (" ++
++ if | Bound sockAddr <- status -> do
++      withSockAddr sockAddr $ \saddr -> c_listen s saddr (fromIntegral backlog)
++      return Listening
++    | otherwise ->
++      ioError $ userError $
++        "Network.Socket.listen: can't listen on socket with non-bound status."
+ 
+ -----------------------------------------------------------------------------
+ -- Accept
+@@ -514,51 +501,20 @@ accept sock@(MkSocket s family stype protocol status) = do
+    then
+      ioError $ userError $
+        "Network.Socket.accept: can't accept socket (" ++
 -         show (family, stype, protocol) ++ ") with status " ++
 -         show currentStatus
--   else do
++         show (family, stype, protocol) ++ ") with status not in position to accept" ++
++         "connections."
+    else do
 -     let sz = sizeOfSockAddrByFamily family
 -     allocaBytes sz $ \ sockaddr -> do
 -#if defined(mingw32_HOST_OS)
@@ -3204,11 +731,13 @@ index 6a1ce6a..0000000
 -# else
 -     new_sock <- throwSocketErrorWaitRead sock "Network.Socket.accept"
 -                        (c_accept s sockaddr ptr_len)
--     setNonBlockIfNeeded new_sock
++     new_sock <- onNothingRetry $ c_accept s
++     addr <- newSockAddr new_sock
+      setNonBlockIfNeeded new_sock
 -# endif /* HAVE_ACCEPT4 */
 -#endif
 -     addr <- peekSockAddr sockaddr
--     new_status <- newMVar Connected
+      new_status <- newMVar Connected
 -     return ((MkSocket new_sock family stype protocol new_status), addr)
 -
 -#if defined(mingw32_HOST_OS)
@@ -3221,79 +750,34 @@ index 6a1ce6a..0000000
 -foreign import ccall unsafe "free"
 -  c_free:: Ptr a -> IO ()
 -#endif
--
-------------------------------------------------------------------------------
---- ** Sending and receiving data
--
---- $sendrecv
----
---- Do not use the @send@ and @recv@ functions defined in this section
---- in new code, as they incorrectly represent binary data as a Unicode
---- string.  As a result, these functions are inefficient and may lead
---- to bugs in the program.  Instead use the @send@ and @recv@
---- functions defined in the "Network.Socket.ByteString" module.
--
-------------------------------------------------------------------------------
---- sendTo & recvFrom
--
---- | Send data to the socket.  The recipient can be specified
---- explicitly, so the socket need not be in a connected state.
---- Returns the number of bytes sent.  Applications are responsible for
---- ensuring that all data has been sent.
----
---- NOTE: blocking on Windows unless you compile with -threaded (see
---- GHC ticket #1129)
--{-# WARNING sendTo "Use sendTo defined in \"Network.Socket.ByteString\"" #-}
--sendTo :: Socket        -- (possibly) bound/connected Socket
--       -> String        -- Data to send
--       -> SockAddr
--       -> IO Int        -- Number of Bytes sent
--sendTo sock xs addr = do
-- withCStringLen xs $ \(str, len) -> do
--   sendBufTo sock str len addr
--
---- | Send data to the socket.  The recipient can be specified
---- explicitly, so the socket need not be in a connected state.
---- Returns the number of bytes sent.  Applications are responsible for
---- ensuring that all data has been sent.
--sendBufTo :: Socket            -- (possibly) bound/connected Socket
--          -> Ptr a -> Int  -- Data to send
--          -> SockAddr
--          -> IO Int            -- Number of Bytes sent
--sendBufTo sock@(MkSocket s _family _stype _protocol _status) ptr nbytes addr = do
++     return ((MkSocket new_sock family (toStype stype) protocol new_status), addr)
++  where onNothingRetry io = do
++          mResult <- io
++          case mResult of
++            Nothing -> threadWaitAccept s >> onNothingRetry io
++            Just ch -> return ch
++        toStype (ServerSocket s) = s
+ 
+ -----------------------------------------------------------------------------
+ -- ** Sending and receiving data
+@@ -599,11 +555,10 @@ sendBufTo :: Socket            -- (possibly) bound/connected Socket
+           -> SockAddr
+           -> IO Int            -- Number of Bytes sent
+ sendBufTo sock@(MkSocket s _family _stype _protocol _status) ptr nbytes addr = do
 - withSockAddr addr $ \p_addr sz -> do
--   liftM fromIntegral $
--     throwSocketErrorWaitWrite sock "Network.Socket.sendTo" $
++ withSockAddr addr $ \p_addr -> do
+    liftM fromIntegral $
+      throwSocketErrorWaitWrite sock "Network.Socket.sendTo" $
 -        c_sendto s ptr (fromIntegral $ nbytes) 0{-flags-}
 -                        p_addr (fromIntegral sz)
--
---- | Receive data from the socket. The socket need not be in a
---- connected state. Returns @(bytes, nbytes, address)@ where @bytes@
---- is a @String@ of length @nbytes@ representing the data received and
---- @address@ is a 'SockAddr' representing the address of the sending
---- socket.
----
---- NOTE: blocking on Windows unless you compile with -threaded (see
---- GHC ticket #1129)
--{-# WARNING recvFrom "Use recvFrom defined in \"Network.Socket.ByteString\"" #-}
--recvFrom :: Socket -> Int -> IO (String, Int, SockAddr)
--recvFrom sock nbytes =
--  allocaBytes nbytes $ \ptr -> do
--    (len, sockaddr) <- recvBufFrom sock ptr nbytes
--    str <- peekCStringLen (ptr, len)
--    return (str, len, sockaddr)
--
---- | Receive data from the socket, writing it into buffer instead of
---- creating a new string.  The socket need not be in a connected
---- state. Returns @(nbytes, address)@ where @nbytes@ is the number of
---- bytes received and @address@ is a 'SockAddr' representing the
---- address of the sending socket.
----
---- NOTE: blocking on Windows unless you compile with -threaded (see
---- GHC ticket #1129)
--recvBufFrom :: Socket -> Ptr a -> Int -> IO (Int, SockAddr)
--recvBufFrom sock@(MkSocket s family _stype _protocol _status) ptr nbytes
-- | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvFrom")
++        c_sendto s ptr (fromIntegral $ nbytes) p_addr
+ 
+ -- | Receive data from the socket. The socket need not be in a
+ -- connected state. Returns @(bytes, nbytes, address)@ where @bytes@
+@@ -632,27 +587,27 @@ recvFrom sock nbytes =
+ recvBufFrom :: Socket -> Ptr a -> Int -> IO (Int, SockAddr)
+ recvBufFrom sock@(MkSocket s family _stype _protocol _status) ptr nbytes
+  | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvFrom")
 - | otherwise   =
 -    withNewSockAddr family $ \ptr_addr sz -> do
 -      alloca $ \ptr_len -> do
@@ -3315,141 +799,79 @@ index 6a1ce6a..0000000
 -                else
 -                   peekSockAddr ptr_addr
 -           return (len', sockaddr)
--
-------------------------------------------------------------------------------
---- send & recv
--
---- | Send data to the socket. The socket must be connected to a remote
---- socket. Returns the number of bytes sent.  Applications are
---- responsible for ensuring that all data has been sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--{-# WARNING send "Use send defined in \"Network.Socket.ByteString\"" #-}
--send :: Socket  -- Bound/Connected Socket
--     -> String  -- Data to send
--     -> IO Int  -- Number of Bytes sent
--send sock xs = withCStringLen xs $ \(str, len) ->
--    sendBuf sock (castPtr str) len
--
---- | Send data to the socket. The socket must be connected to a remote
---- socket. Returns the number of bytes sent.  Applications are
---- responsible for ensuring that all data has been sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendBuf :: Socket     -- Bound/Connected Socket
--        -> Ptr Word8  -- Pointer to the data to send
--        -> Int        -- Length of the buffer
--        -> IO Int     -- Number of Bytes sent
--sendBuf sock@(MkSocket s _family _stype _protocol _status) str len = do
--   liftM fromIntegral $
++ | otherwise   = error "recvBufFrom: Not implemented yet"
++    -- withNewSockAddr family $ \ptr_addr sz -> do
++    --   alloca $ \ptr_len -> do
++    --     poke ptr_len (fromIntegral sz)
++    --     len <- throwSocketErrorWaitRead sock "Network.Socket.recvFrom" $
++    --                c_recvfrom s ptr (fromIntegral nbytes) 0{-flags-}
++    --                             ptr_addr ptr_len
++    --     let len' = fromIntegral len
++    --     if len' == 0
++    --      then ioError (mkEOFError "Network.Socket.recvFrom")
++    --      else do
++    --        flg <- isConnected sock
++    --          -- For at least one implementation (WinSock 2), recvfrom() ignores
++    --          -- filling in the sockaddr for connected TCP sockets. Cope with
++    --          -- this by using getPeerName instead.
++    --        sockaddr <-
++    --             if flg then
++    --                getPeerName sock
++    --             else
++    --                peekSockAddr ptr_addr
++    --        return (len', sockaddr)
+ 
+ -----------------------------------------------------------------------------
+ -- send & recv
+@@ -679,23 +634,18 @@ sendBuf :: Socket     -- Bound/Connected Socket
+         -> Int        -- Length of the buffer
+         -> IO Int     -- Number of Bytes sent
+ sendBuf sock@(MkSocket s _family _stype _protocol _status) str len = do
++   fd <- socket2FD sock
+    liftM fromIntegral $
 -#if defined(mingw32_HOST_OS)
---- writeRawBufferPtr is supposed to handle checking for errors, but it's broken
---- on x86_64 because of GHC bug #12010 so we duplicate the check here. The call
---- to throwSocketErrorIfMinus1Retry can be removed when no GHC version with the
---- bug is supported.
--    throwSocketErrorIfMinus1Retry "Network.Socket.sendBuf" $ writeRawBufferPtr
--      "Network.Socket.sendBuf"
+ -- writeRawBufferPtr is supposed to handle checking for errors, but it's broken
+ -- on x86_64 because of GHC bug #12010 so we duplicate the check here. The call
+ -- to throwSocketErrorIfMinus1Retry can be removed when no GHC version with the
+ -- bug is supported.
+     throwSocketErrorIfMinus1Retry "Network.Socket.sendBuf" $ writeRawBufferPtr
+       "Network.Socket.sendBuf"
 -      (socket2FD sock)
--      (castPtr str)
--      0
--      (fromIntegral len)
++      fd
+       (castPtr str)
+       0
+       (fromIntegral len)
 -#else
 -     throwSocketErrorWaitWrite sock "Network.Socket.sendBuf" $
 -        c_send s str (fromIntegral len) 0{-flags-}
 -#endif
 -
--
---- | Receive data from the socket.  The socket must be in a connected
---- state. This function may return fewer bytes than specified.  If the
---- message is longer than the specified length, it may be discarded
---- depending on the type of socket.  This function may block until a
---- message arrives.
----
---- Considering hardware and network realities, the maximum number of
---- bytes to receive should be a small power of 2, e.g., 4096.
----
---- For TCP sockets, a zero length return value means the peer has
---- closed its half side of the connection.
----
---- Receiving data from closed socket may lead to undefined behaviour.
--{-# WARNING recv "Use recv defined in \"Network.Socket.ByteString\"" #-}
--recv :: Socket -> Int -> IO String
--recv sock l = fst <$> recvLen sock l
--
--{-# WARNING recvLen "Use recvLen defined in \"Network.Socket.ByteString\"" #-}
--recvLen :: Socket -> Int -> IO (String, Int)
--recvLen sock nbytes =
--     allocaBytes nbytes $ \ptr -> do
--        len <- recvBuf sock ptr nbytes
--        s <- peekCStringLen (castPtr ptr,len)
--        return (s, len)
--
---- | Receive data from the socket.  The socket must be in a connected
---- state. This function may return fewer bytes than specified.  If the
---- message is longer than the specified length, it may be discarded
---- depending on the type of socket.  This function may block until a
---- message arrives.
----
---- Considering hardware and network realities, the maximum number of
---- bytes to receive should be a small power of 2, e.g., 4096.
----
---- For TCP sockets, a zero length return value means the peer has
---- closed its half side of the connection.
----
---- Receiving data from closed socket may lead to undefined behaviour.
--recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
--recvBuf sock@(MkSocket s _family _stype _protocol _status) ptr nbytes
-- | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBuf")
-- | otherwise   = do
--        len <-
+ 
+ -- | Receive data from the socket.  The socket must be in a connected
+ -- state. This function may return fewer bytes than specified.  If the
+@@ -739,16 +689,12 @@ recvBuf :: Socket -> Ptr Word8 -> Int -> IO Int
+ recvBuf sock@(MkSocket s _family _stype _protocol _status) ptr nbytes
+  | nbytes <= 0 = ioError (mkInvalidRecvArgError "Network.Socket.recvBuf")
+  | otherwise   = do
++        fd <- socket2FD sock
+         len <-
 -#if defined(mingw32_HOST_OS)
---- see comment in sendBuf above.
--            throwSocketErrorIfMinus1Retry "Network.Socket.recvBuf" $
--                readRawBufferPtr "Network.Socket.recvBuf"
+ -- see comment in sendBuf above.
+             throwSocketErrorIfMinus1Retry "Network.Socket.recvBuf" $
+                 readRawBufferPtr "Network.Socket.recvBuf"
 -                (socket2FD sock) ptr 0 (fromIntegral nbytes)
 -#else
 -               throwSocketErrorWaitRead sock "Network.Socket.recvBuf" $
 -                   c_recv s (castPtr ptr) (fromIntegral nbytes) 0{-flags-}
 -#endif
--        let len' = fromIntegral len
--        if len' == 0
--         then ioError (mkEOFError "Network.Socket.recvBuf")
--         else return len'
--
--
---- ---------------------------------------------------------------------------
---- socketPort
----
---- The port number the given socket is currently connected to can be
---- determined by calling $port$, is generally only useful when bind
---- was given $aNY\_PORT$.
--
--socketPort :: Socket            -- Connected & Bound Socket
--           -> IO PortNumber     -- Port Number of Socket
--socketPort sock@(MkSocket _ AF_INET _ _ _) = do
--    (SockAddrInet port _) <- getSocketName sock
--    return port
--#if defined(IPV6_SOCKET_SUPPORT)
--socketPort sock@(MkSocket _ AF_INET6 _ _ _) = do
--    (SockAddrInet6 port _ _ _) <- getSocketName sock
--    return port
--#endif
--socketPort (MkSocket _ family _ _ _) =
--    ioError $ userError $
--      "Network.Socket.socketPort: address family '" ++ show family ++
--      "' not supported."
--
--
---- ---------------------------------------------------------------------------
---- getPeerName
--
---- Calling $getPeerName$ returns the address details of the machine,
---- other than the local one, which is connected to the socket. This is
---- used in programs such as FTP to determine where to send the
---- returning data.  The corresponding call to get the details of the
---- local machine is $getSocketName$.
--
--getPeerName   :: Socket -> IO SockAddr
++                fd ptr 0 (fromIntegral nbytes)
+         let len' = fromIntegral len
+         if len' == 0
+          then ioError (mkEOFError "Network.Socket.recvBuf")
+@@ -788,21 +734,12 @@ socketPort (MkSocket _ family _ _ _) =
+ -- local machine is $getSocketName$.
+ 
+ getPeerName   :: Socket -> IO SockAddr
 -getPeerName (MkSocket s family _ _ _) = do
 - withNewSockAddr family $ \ptr sz -> do
 -   with (fromIntegral sz) $ \int_star -> do
@@ -3457,69 +879,34 @@ index 6a1ce6a..0000000
 -     c_getpeername s ptr int_star
 -   _sz <- peek int_star
 -   peekSockAddr ptr
--
--getSocketName :: Socket -> IO SockAddr
++getPeerName (MkSocket s family _ _ _) =
++  error $ "Network.Socket.getPeerName: Not implemented yet."
+ 
+ getSocketName :: Socket -> IO SockAddr
 -getSocketName (MkSocket s family _ _ _) = do
 - withNewSockAddr family $ \ptr sz -> do
 -   with (fromIntegral sz) $ \int_star -> do
 -   throwSocketErrorIfMinus1Retry_ "Network.Socket.getSocketName" $
 -     c_getsockname s ptr int_star
 -   peekSockAddr ptr
--
-------------------------------------------------------------------------------
---- Socket Properties
--
---- | Socket options for use with 'setSocketOption' and 'getSocketOption'.
----
---- The existence of a constructor does not imply that the relevant option
---- is supported on your system: see 'isSupportedSocketOption'
--data SocketOption
--    = Debug         -- ^ SO_DEBUG
--    | ReuseAddr     -- ^ SO_REUSEADDR
--    | Type          -- ^ SO_TYPE
--    | SoError       -- ^ SO_ERROR
--    | DontRoute     -- ^ SO_DONTROUTE
--    | Broadcast     -- ^ SO_BROADCAST
--    | SendBuffer    -- ^ SO_SNDBUF
--    | RecvBuffer    -- ^ SO_RCVBUF
--    | KeepAlive     -- ^ SO_KEEPALIVE
--    | OOBInline     -- ^ SO_OOBINLINE
--    | TimeToLive    -- ^ IP_TTL
--    | MaxSegment    -- ^ TCP_MAXSEG
--    | NoDelay       -- ^ TCP_NODELAY
--    | Cork          -- ^ TCP_CORK
--    | Linger        -- ^ SO_LINGER
--    | ReusePort     -- ^ SO_REUSEPORT
--    | RecvLowWater  -- ^ SO_RCVLOWAT
--    | SendLowWater  -- ^ SO_SNDLOWAT
--    | RecvTimeOut   -- ^ SO_RCVTIMEO
--    | SendTimeOut   -- ^ SO_SNDTIMEO
--    | UseLoopBack   -- ^ SO_USELOOPBACK
--    | UserTimeout   -- ^ TCP_USER_TIMEOUT
--    | IPv6Only      -- ^ IPV6_V6ONLY
--    | CustomSockOpt (CInt, CInt)
--    deriving (Show, Typeable)
--
---- | Does the 'SocketOption' exist on this system?
--isSupportedSocketOption :: SocketOption -> Bool
--isSupportedSocketOption = isJust . packSocketOption
--
---- | For a socket option, return Just (level, value) where level is the
---- corresponding C option level constant (e.g. SOL_SOCKET) and value is
---- the option constant itself (e.g. SO_DEBUG)
---- If either constant does not exist, return Nothing.
++getSocketName (MkSocket s family _ _ _) =
++  error $ "Network.Socket.getSocketName: Not implemented yet."
+ 
+ -----------------------------------------------------------------------------
+ -- Socket Properties
+@@ -846,7 +783,7 @@ isSupportedSocketOption = isJust . packSocketOption
+ -- corresponding C option level constant (e.g. SOL_SOCKET) and value is
+ -- the option constant itself (e.g. SO_DEBUG)
+ -- If either constant does not exist, return Nothing.
 -packSocketOption :: SocketOption -> Maybe (CInt, CInt)
--packSocketOption so =
--  -- The Just here is a hack to disable GHC's overlapping pattern detection:
--  -- the problem is if all constants are present, the fallback pattern is
--  -- redundant, but if they aren't then it isn't. Hence we introduce an
--  -- extra pattern (Nothing) that can't possibly happen, so that the
--  -- fallback is always (in principle) necessary.
--  -- I feel a little bad for including this, but such are the sacrifices we
--  -- make while working with CPP - excluding the fallback pattern correctly
--  -- would be a serious nuisance.
--  -- (NB: comments elsewhere in this file refer to this one)
--  case Just so of
++packSocketOption :: SocketOption -> Maybe SOption
+ packSocketOption so =
+   -- The Just here is a hack to disable GHC's overlapping pattern detection:
+   -- the problem is if all constants are present, the fallback pattern is
+@@ -858,90 +795,19 @@ packSocketOption so =
+   -- would be a serious nuisance.
+   -- (NB: comments elsewhere in this file refer to this one)
+   case Just so of
 -#ifdef SOL_SOCKET
 -#ifdef SO_DEBUG
 -    Just Debug         -> Just ((#const SOL_SOCKET), (#const SO_DEBUG))
@@ -3599,23 +986,27 @@ index 6a1ce6a..0000000
 -#endif // HAVE_DECL_IPPROTO_IPV6
 -    Just (CustomSockOpt opt) -> Just opt
 -    _             -> Nothing
--
---- | Return the option level and option value if they exist,
---- otherwise throw an error that begins "Network.Socket." ++ the String
---- parameter
++    Just ReuseAddr     -> Just sO_REUSEADDR
++    Just Broadcast     -> Just sO_BROADCAST
++    Just SendBuffer    -> Just sO_SNDBUF
++    Just RecvBuffer    -> Just sO_RCVBUF
++    Just KeepAlive     -> Just sO_KEEPALIVE
++    Just Linger        -> Just sO_LINGER
++    Just NoDelay       -> Just tCP_NODELAY
++    _                  -> Nothing
+ 
+ -- | Return the option level and option value if they exist,
+ -- otherwise throw an error that begins "Network.Socket." ++ the String
+ -- parameter
 -packSocketOption' :: String -> SocketOption -> IO (CInt, CInt)
--packSocketOption' caller so = maybe err return (packSocketOption so)
-- where
--  err = ioError . userError . concat $ ["Network.Socket.", caller,
--    ": socket option ", show so, " unsupported on this system"]
--
---- | Set a socket option that expects an Int value.
---- There is currently no API to set e.g. the timeval socket options
--setSocketOption :: Socket
--                -> SocketOption -- Option Name
--                -> Int          -- Option Value
--                -> IO ()
--setSocketOption (MkSocket s _ _ _ _) so v = do
++packSocketOption' :: String -> SocketOption -> IO SOption
+ packSocketOption' caller so = maybe err return (packSocketOption so)
+  where
+   err = ioError . userError . concat $ ["Network.Socket.", caller,
+@@ -954,13 +820,8 @@ setSocketOption :: Socket
+                 -> Int          -- Option Value
+                 -> IO ()
+ setSocketOption (MkSocket s _ _ _ _) so v = do
 -   (level, opt) <- packSocketOption' "setSocketOption" so
 -   with (fromIntegral v) $ \ptr_v -> do
 -   throwSocketErrorIfMinus1_ "Network.Socket.setSocketOption" $
@@ -3623,13 +1014,15 @@ index 6a1ce6a..0000000
 -          (fromIntegral (sizeOf (undefined :: CInt)))
 -   return ()
 -
--
---- | Get a socket option that gives an Int value.
---- There is currently no API to get e.g. the timeval socket options
--getSocketOption :: Socket
--                -> SocketOption  -- Option Name
--                -> IO Int        -- Option Value
--getSocketOption (MkSocket s _ _ _ _) so = do
++   opt <- packSocketOption' "setSocketOption" so
++   c_setsockopt s opt (fromIntegral v)
+ 
+ -- | Get a socket option that gives an Int value.
+ -- There is currently no API to get e.g. the timeval socket options
+@@ -968,13 +829,8 @@ getSocketOption :: Socket
+                 -> SocketOption  -- Option Name
+                 -> IO Int        -- Option Value
+ getSocketOption (MkSocket s _ _ _ _) so = do
 -   (level, opt) <- packSocketOption' "getSocketOption" so
 -   alloca $ \ptr_v ->
 -     with (fromIntegral (sizeOf (undefined :: CInt))) $ \ptr_sz -> do
@@ -3637,342 +1030,123 @@ index 6a1ce6a..0000000
 -         c_getsockopt s level opt ptr_v ptr_sz
 -       fromIntegral `liftM` peek ptr_v
 -
--
--#if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
---- | Returns the processID, userID and groupID of the socket's peer.
----
---- Only available on platforms that support SO_PEERCRED or GETPEEREID(3)
---- on domain sockets.
---- GETPEEREID(3) returns userID and groupID. processID is always 0.
--getPeerCred :: Socket -> IO (CUInt, CUInt, CUInt)
--getPeerCred sock = do
--#ifdef HAVE_STRUCT_UCRED
--  let fd = fdSocket sock
--  let sz = (#const sizeof(struct ucred))
--  allocaBytes sz $ \ ptr_cr ->
--   with (fromIntegral sz) $ \ ptr_sz -> do
--     _ <- ($) throwSocketErrorIfMinus1Retry "Network.Socket.getPeerCred" $
--       c_getsockopt fd (#const SOL_SOCKET) (#const SO_PEERCRED) ptr_cr ptr_sz
--     pid <- (#peek struct ucred, pid) ptr_cr
--     uid <- (#peek struct ucred, uid) ptr_cr
--     gid <- (#peek struct ucred, gid) ptr_cr
--     return (pid, uid, gid)
--#else
--  (uid,gid) <- getPeerEid sock
--  return (0,uid,gid)
--#endif
--
--#ifdef HAVE_GETPEEREID
---- | The getpeereid() function returns the effective user and group IDs of the
---- peer connected to a UNIX-domain socket
--getPeerEid :: Socket -> IO (CUInt, CUInt)
--getPeerEid sock = do
--  let fd = fdSocket sock
--  alloca $ \ ptr_uid ->
--    alloca $ \ ptr_gid -> do
--      throwSocketErrorIfMinus1Retry_ "Network.Socket.getPeerEid" $
--        c_getpeereid fd ptr_uid ptr_gid
--      uid <- peek ptr_uid
--      gid <- peek ptr_gid
--      return (uid, gid)
--#endif
--#endif
--
++   opt <- packSocketOption' "getSocketOption" so
++   fmap fromIntegral $ c_getsockopt s opt
+ 
+ #if defined(HAVE_STRUCT_UCRED) || defined(HAVE_GETPEEREID)
+ -- | Returns the processID, userID and groupID of the socket's peer.
+@@ -1016,10 +872,6 @@ getPeerEid sock = do
+ #endif
+ #endif
+ 
 -##if !(MIN_VERSION_base(4,3,1))
 -closeFdWith closer fd = closer fd
 -##endif
 -
--#if defined(DOMAIN_SOCKET_SUPPORT)
---- sending/receiving ancillary socket data; low-level mechanism
---- for transmitting file descriptors, mainly.
--sendFd :: Socket -> CInt -> IO ()
--sendFd sock outfd = do
--  _ <- ($) throwSocketErrorWaitWrite sock "Network.Socket.sendFd" $
--     c_sendFd (fdSocket sock) outfd
--   -- Note: If Winsock supported FD-passing, thi would have been
--   -- incorrect (since socket FDs need to be closed via closesocket().)
--  closeFd outfd
--
---- | Receive a file descriptor over a domain socket. Note that the resulting
---- file descriptor may have to be put into non-blocking mode in order to be
---- used safely. See 'setNonBlockIfNeeded'.
--recvFd :: Socket -> IO CInt
--recvFd sock = do
--  theFd <- throwSocketErrorWaitRead sock "Network.Socket.recvFd" $
--               c_recvFd (fdSocket sock)
--  return theFd
--
--foreign import ccall SAFE_ON_WIN "sendFd" c_sendFd :: CInt -> CInt -> IO CInt
--foreign import ccall SAFE_ON_WIN "recvFd" c_recvFd :: CInt -> IO CInt
--
--#endif
--
---- ---------------------------------------------------------------------------
---- Utility Functions
--
--aNY_PORT :: PortNumber
--aNY_PORT = 0
--
---- | The IPv4 wild card address.
--
--iNADDR_ANY :: HostAddress
+ #if defined(DOMAIN_SOCKET_SUPPORT)
+ -- sending/receiving ancillary socket data; low-level mechanism
+ -- for transmitting file descriptors, mainly.
+@@ -1054,12 +906,12 @@ aNY_PORT = 0
+ -- | The IPv4 wild card address.
+ 
+ iNADDR_ANY :: HostAddress
 -iNADDR_ANY = htonl (#const INADDR_ANY)
--
---- | Converts the from host byte order to network byte order.
++iNADDR_ANY = 0
+ 
+ -- | Converts the from host byte order to network byte order.
 -foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
 --- | Converts the from network byte order to host byte order.
 -foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
--
--#if defined(IPV6_SOCKET_SUPPORT)
---- | The IPv6 wild card address.
--
--iN6ADDR_ANY :: HostAddress6
--iN6ADDR_ANY = (0, 0, 0, 0)
--#endif
--
--sOMAXCONN :: Int
++-- foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
++-- -- | Converts the from network byte order to host byte order.
++-- foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
+ 
+ #if defined(IPV6_SOCKET_SUPPORT)
+ -- | The IPv6 wild card address.
+@@ -1069,10 +921,10 @@ iN6ADDR_ANY = (0, 0, 0, 0)
+ #endif
+ 
+ sOMAXCONN :: Int
 -sOMAXCONN = #const SOMAXCONN
--
--sOL_SOCKET :: Int
++sOMAXCONN = 50
+ 
+ sOL_SOCKET :: Int
 -sOL_SOCKET = #const SOL_SOCKET
--
--#ifdef SCM_RIGHTS
--sCM_RIGHTS :: Int
--sCM_RIGHTS = #const SCM_RIGHTS
--#endif
--
---- | This is the value of SOMAXCONN, typically 128.
---- 128 is good enough for normal network servers but
---- is too small for high performance servers.
--maxListenQueue :: Int
--maxListenQueue = sOMAXCONN
--
---- -----------------------------------------------------------------------------
--
--data ShutdownCmd
-- = ShutdownReceive
-- | ShutdownSend
-- | ShutdownBoth
-- deriving Typeable
--
--sdownCmdToInt :: ShutdownCmd -> CInt
--sdownCmdToInt ShutdownReceive = 0
--sdownCmdToInt ShutdownSend    = 1
--sdownCmdToInt ShutdownBoth    = 2
--
---- | Shut down one or both halves of the connection, depending on the
---- second argument to the function.  If the second argument is
---- 'ShutdownReceive', further receives are disallowed.  If it is
---- 'ShutdownSend', further sends are disallowed.  If it is
---- 'ShutdownBoth', further sends and receives are disallowed.
--shutdown :: Socket -> ShutdownCmd -> IO ()
--shutdown (MkSocket s _ _ _ _) stype = do
--  throwSocketErrorIfMinus1Retry_ "Network.Socket.shutdown" $
--    c_shutdown s (sdownCmdToInt stype)
--  return ()
--
---- -----------------------------------------------------------------------------
--
---- | Close the socket. Sending data to or receiving data from closed socket
---- may lead to undefined behaviour.
--close :: Socket -> IO ()
--close (MkSocket s _ _ _ socketStatus) = do
-- modifyMVar_ socketStatus $ \ status ->
--   case status of
--     ConvertedToHandle ->
--         ioError (userError ("close: converted to a Handle, use hClose instead"))
--     Closed ->
--         return status
++sOL_SOCKET = 0
+ 
+ #ifdef SCM_RIGHTS
+ sCM_RIGHTS :: Int
+@@ -1121,7 +973,7 @@ close (MkSocket s _ _ _ socketStatus) = do
+          ioError (userError ("close: converted to a Handle, use hClose instead"))
+      Closed ->
+          return status
 -     _ -> closeFdWith (closeFd . fromIntegral) (fromIntegral s) >> return Closed
--
---- -----------------------------------------------------------------------------
--
---- | Determines whether 'close' has been used on the 'Socket'. This
---- does /not/ indicate any status about the socket beyond this. If the
---- socket has been closed remotely, this function can still return
---- 'True'.
--isConnected :: Socket -> IO Bool
--isConnected (MkSocket _ _ _ _ status) = do
--    value <- readMVar status
--    return (value == Connected)
--
---- -----------------------------------------------------------------------------
---- Socket Predicates
--
--isBound :: Socket -> IO Bool
--isBound (MkSocket _ _ _ _ status) = do
--    value <- readMVar status
++     _ -> closeFdWith closeFd s >> return Closed
+ 
+ -- -----------------------------------------------------------------------------
+ 
+@@ -1140,7 +992,9 @@ isConnected (MkSocket _ _ _ _ status) = do
+ isBound :: Socket -> IO Bool
+ isBound (MkSocket _ _ _ _ status) = do
+     value <- readMVar status
 -    return (value == Bound)
--
--isListening :: Socket -> IO Bool
--isListening (MkSocket _ _ _  _ status) = do
--    value <- readMVar status
--    return (value == Listening)
--
--isReadable  :: Socket -> IO Bool
--isReadable (MkSocket _ _ _ _ status) = do
--    value <- readMVar status
--    return (value == Listening || value == Connected)
--
--isWritable  :: Socket -> IO Bool
--isWritable = isReadable -- sort of.
--
--isAcceptable :: Socket -> IO Bool
--#if defined(DOMAIN_SOCKET_SUPPORT)
--isAcceptable (MkSocket _ AF_UNIX x _ status)
--    | x == Stream || x == SeqPacket = do
--        value <- readMVar status
--        return (value == Connected || value == Bound || value == Listening)
--isAcceptable (MkSocket _ AF_UNIX _ _ _) = return False
--#endif
--isAcceptable (MkSocket _ _ _ _ status) = do
--    value <- readMVar status
--    return (value == Connected || value == Listening)
--
---- -----------------------------------------------------------------------------
---- Internet address manipulation routines:
--
--inet_addr :: String -> IO HostAddress
--inet_addr ipstr = withSocketsDo $ do
++    return $ case value of
++      Bound _ -> True
++      _ -> False
+ 
+ isListening :: Socket -> IO Bool
+ isListening (MkSocket _ _ _  _ status) = do
+@@ -1172,17 +1026,14 @@ isAcceptable (MkSocket _ _ _ _ status) = do
+ 
+ inet_addr :: String -> IO HostAddress
+ inet_addr ipstr = withSocketsDo $ do
 -   withCString ipstr $ \str -> do
 -   had <- c_inet_addr str
--   if had == -1
--    then ioError $ userError $
--      "Network.Socket.inet_addr: Malformed address: " ++ ipstr
--    else return had  -- network byte order
--
--inet_ntoa :: HostAddress -> IO String
++   had <- c_inet_addr ipstr
+    if had == -1
+     then ioError $ userError $
+       "Network.Socket.inet_addr: Malformed address: " ++ ipstr
+     else return had  -- network byte order
+ 
+ inet_ntoa :: HostAddress -> IO String
 -inet_ntoa haddr = withSocketsDo $ do
 -  pstr <- c_inet_ntoa haddr
 -  peekCString pstr
--
---- | Turns a Socket into an 'Handle'. By default, the new handle is
---- unbuffered. Use 'System.IO.hSetBuffering' to change the buffering.
----
---- Note that since a 'Handle' is automatically closed by a finalizer
---- when it is no longer referenced, you should avoid doing any more
---- operations on the 'Socket' after calling 'socketToHandle'.  To
---- close the 'Socket' after 'socketToHandle', call 'System.IO.hClose'
---- on the 'Handle'.
--
--socketToHandle :: Socket -> IOMode -> IO Handle
--socketToHandle s@(MkSocket fd _ _ _ socketStatus) mode = do
-- modifyMVar socketStatus $ \ status ->
--    if status == ConvertedToHandle
--        then ioError (userError ("socketToHandle: already a Handle"))
--        else do
++inet_ntoa haddr = withSocketsDo $ c_inet_ntoa haddr
+ 
+ -- | Turns a Socket into an 'Handle'. By default, the new handle is
+ -- unbuffered. Use 'System.IO.hSetBuffering' to change the buffering.
+@@ -1199,7 +1050,7 @@ socketToHandle s@(MkSocket fd _ _ _ socketStatus) mode = do
+     if status == ConvertedToHandle
+         then ioError (userError ("socketToHandle: already a Handle"))
+         else do
 -    h <- fdToHandle' (fromIntegral fd) (Just GHC.IO.Device.Stream) True (show s) mode True{-bin-}
--    hSetBuffering h NoBuffering
--    return (ConvertedToHandle, h)
--
---- | Pack a list of values into a bitmask.  The possible mappings from
---- value to bit-to-set are given as the first argument.  We assume
---- that each value can cause exactly one bit to be set; unpackBits will
---- break if this property is not true.
--
--packBits :: (Eq a, Num b, Bits b) => [(a, b)] -> [a] -> b
--
--packBits mapping xs = foldl' pack 0 mapping
--    where pack acc (k, v) | k `elem` xs = acc .|. v
--                          | otherwise   = acc
--
---- | Unpack a bitmask into a list of values.
--
--unpackBits :: (Num b, Bits b) => [(a, b)] -> b -> [a]
--
---- Be permissive and ignore unknown bit values. At least on OS X,
---- getaddrinfo returns an ai_flags field with bits set that have no
---- entry in <netdb.h>.
--unpackBits [] _    = []
--unpackBits ((k,v):xs) r
--    | r .&. v /= 0 = k : unpackBits xs (r .&. complement v)
--    | otherwise    = unpackBits xs r
--
-------------------------------------------------------------------------------
---- Address and service lookups
--
--#if defined(IPV6_SOCKET_SUPPORT)
--
---- | Flags that control the querying behaviour of 'getAddrInfo'.
----   For more information, see <https://tools.ietf.org/html/rfc3493#page-25>
--data AddrInfoFlag =
--    -- | The list of returned 'AddrInfo' values will
--    --   only contain IPv4 addresses if the local system has at least
--    --   one IPv4 interface configured, and likewise for IPv6.
--    --   (Only some platforms support this.)
--      AI_ADDRCONFIG
--    -- | If 'AI_ALL' is specified, return all matching IPv6 and
--    --   IPv4 addresses.  Otherwise, this flag has no effect.
--    --   (Only some platforms support this.)
--    | AI_ALL
--    -- | The 'addrCanonName' field of the first returned
--    --   'AddrInfo' will contain the "canonical name" of the host.
--    | AI_CANONNAME
--    -- | The 'HostName' argument /must/ be a numeric
--    --   address in string form, and network name lookups will not be
--    --   attempted.
--    | AI_NUMERICHOST
--    -- | The 'ServiceName' argument /must/ be a port
--    --   number in string form, and service name lookups will not be
--    --   attempted. (Only some platforms support this.)
--    | AI_NUMERICSERV
--    -- | If no 'HostName' value is provided, the network
--    --   address in each 'SockAddr'
--    --   will be left as a "wild card", i.e. as either 'iNADDR_ANY'
--    --   or 'iN6ADDR_ANY'.  This is useful for server applications that
--    --   will accept connections from any client.
--    | AI_PASSIVE
--    -- | If an IPv6 lookup is performed, and no IPv6
--    --   addresses are found, IPv6-mapped IPv4 addresses will be
--    --   returned. (Only some platforms support this.)
--    | AI_V4MAPPED
--    deriving (Eq, Read, Show, Typeable)
--
--aiFlagMapping :: [(AddrInfoFlag, CInt)]
--
--aiFlagMapping =
--    [
--#if HAVE_DECL_AI_ADDRCONFIG
--     (AI_ADDRCONFIG, #const AI_ADDRCONFIG),
--#else
--     (AI_ADDRCONFIG, 0),
--#endif
--#if HAVE_DECL_AI_ALL
--     (AI_ALL, #const AI_ALL),
--#else
--     (AI_ALL, 0),
--#endif
++    h <- fdToHandle' fd (Just GHC.IO.Device.Stream) True Nothing mode True{-bin-}
+     hSetBuffering h NoBuffering
+     return (ConvertedToHandle, h)
+ 
+@@ -1280,14 +1131,14 @@ aiFlagMapping =
+ #else
+      (AI_ALL, 0),
+ #endif
 -     (AI_CANONNAME, #const AI_CANONNAME),
 -     (AI_NUMERICHOST, #const AI_NUMERICHOST),
--#if HAVE_DECL_AI_NUMERICSERV
--     (AI_NUMERICSERV, #const AI_NUMERICSERV),
--#else
--     (AI_NUMERICSERV, 0),
--#endif
++     (AI_CANONNAME, 0),
++     (AI_NUMERICHOST, 0),
+ #if HAVE_DECL_AI_NUMERICSERV
+      (AI_NUMERICSERV, #const AI_NUMERICSERV),
+ #else
+      (AI_NUMERICSERV, 0),
+ #endif
 -     (AI_PASSIVE, #const AI_PASSIVE),
--#if HAVE_DECL_AI_V4MAPPED
--     (AI_V4MAPPED, #const AI_V4MAPPED)
--#else
--     (AI_V4MAPPED, 0)
--#endif
--    ]
--
---- | Indicate whether the given 'AddrInfoFlag' will have any effect on
---- this system.
--addrInfoFlagImplemented :: AddrInfoFlag -> Bool
--addrInfoFlagImplemented f = packBits aiFlagMapping [f] /= 0
--
--data AddrInfo =
--    AddrInfo {
--        addrFlags :: [AddrInfoFlag],
--        addrFamily :: Family,
--        addrSocketType :: SocketType,
--        addrProtocol :: ProtocolNumber,
--        addrAddress :: SockAddr,
--        addrCanonName :: Maybe String
--        }
--    deriving (Eq, Show, Typeable)
--
++     (AI_PASSIVE, 0),
+ #if HAVE_DECL_AI_V4MAPPED
+      (AI_V4MAPPED, #const AI_V4MAPPED)
+ #else
+@@ -1311,48 +1162,6 @@ data AddrInfo =
+         }
+     deriving (Eq, Show, Typeable)
+ 
 -instance Storable AddrInfo where
 -    sizeOf    _ = #const sizeof(struct addrinfo)
 -    alignment _ = alignment (undefined :: CInt)
@@ -4015,106 +1189,30 @@ index 6a1ce6a..0000000
 -        (#poke struct addrinfo, ai_canonname) p nullPtr
 -        (#poke struct addrinfo, ai_next) p nullPtr
 -
---- | Flags that control the querying behaviour of 'getNameInfo'.
----   For more information, see <https://tools.ietf.org/html/rfc3493#page-30>
--data NameInfoFlag =
--    -- | Resolve a datagram-based service name.  This is
--    --   required only for the few protocols that have different port
--    --   numbers for their datagram-based versions than for their
--    --   stream-based versions.
--      NI_DGRAM
--    -- | If the hostname cannot be looked up, an IO error is thrown.
--    | NI_NAMEREQD
--    -- | If a host is local, return only the hostname part of the FQDN.
--    | NI_NOFQDN
--    -- | The name of the host is not looked up.
--    --   Instead, a numeric representation of the host's
--    --   address is returned.  For an IPv4 address, this will be a
--    --   dotted-quad string.  For IPv6, it will be colon-separated
--    --   hexadecimal.
--    | NI_NUMERICHOST
--    -- | The name of the service is not
--    --   looked up.  Instead, a numeric representation of the
--    --   service is returned.
--    | NI_NUMERICSERV
--    deriving (Eq, Read, Show, Typeable)
--
--niFlagMapping :: [(NameInfoFlag, CInt)]
--
+ -- | Flags that control the querying behaviour of 'getNameInfo'.
+ --   For more information, see <https://tools.ietf.org/html/rfc3493#page-30>
+ data NameInfoFlag =
+@@ -1379,11 +1188,11 @@ data NameInfoFlag =
+ 
+ niFlagMapping :: [(NameInfoFlag, CInt)]
+ 
 -niFlagMapping = [(NI_DGRAM, #const NI_DGRAM),
 -                 (NI_NAMEREQD, #const NI_NAMEREQD),
 -                 (NI_NOFQDN, #const NI_NOFQDN),
 -                 (NI_NUMERICHOST, #const NI_NUMERICHOST),
 -                 (NI_NUMERICSERV, #const NI_NUMERICSERV)]
--
---- | Default hints for address lookup with 'getAddrInfo'.  The values
---- of the 'addrAddress' and 'addrCanonName' fields are 'undefined',
---- and are never inspected by 'getAddrInfo'.
----
---- >>> addrFlags defaultHints
---- []
---- >>> addrFamily defaultHints
---- AF_UNSPEC
---- >>> addrSocketType defaultHints
---- NoSocketType
---- >>> addrProtocol defaultHints
---- 0
--
--defaultHints :: AddrInfo
--defaultHints = AddrInfo {
--                         addrFlags = [],
--                         addrFamily = AF_UNSPEC,
--                         addrSocketType = NoSocketType,
--                         addrProtocol = defaultProtocol,
--                         addrAddress = undefined,
--                         addrCanonName = undefined
--                        }
--
---- | Resolve a host or service name to one or more addresses.
---- The 'AddrInfo' values that this function returns contain 'SockAddr'
---- values that you can pass directly to 'connect' or
---- 'bind'.
----
---- This function is protocol independent.  It can return both IPv4 and
---- IPv6 address information.
----
---- The 'AddrInfo' argument specifies the preferred query behaviour,
---- socket options, or protocol.  You can override these conveniently
---- using Haskell's record update syntax on 'defaultHints', for example
---- as follows:
----
---- >>> let hints = defaultHints { addrFlags = [AI_NUMERICHOST], addrSocketType = Stream }
----
---- You must provide a 'Just' value for at least one of the 'HostName'
---- or 'ServiceName' arguments.  'HostName' can be either a numeric
---- network address (dotted quad for IPv4, colon-separated hex for
---- IPv6) or a hostname.  In the latter case, its addresses will be
---- looked up unless 'AI_NUMERICHOST' is specified as a hint.  If you
---- do not provide a 'HostName' value /and/ do not set 'AI_PASSIVE' as
---- a hint, network addresses in the result will contain the address of
---- the loopback interface.
----
---- If the query fails, this function throws an IO exception instead of
---- returning an empty list.  Otherwise, it returns a non-empty list
---- of 'AddrInfo' values.
----
---- There are several reasons why a query might result in several
---- values.  For example, the queried-for host could be multihomed, or
---- the service might be available via several protocols.
----
---- Note: the order of arguments is slightly different to that defined
---- for @getaddrinfo@ in RFC 2553.  The 'AddrInfo' parameter comes first
---- to make partial application easier.
----
---- >>> addr:_ <- getAddrInfo (Just hints) (Just "127.0.0.1") (Just "http")
---- >>> addrAddress addr
---- 127.0.0.1:80
--
--getAddrInfo :: Maybe AddrInfo -- ^ preferred socket type or protocol
--            -> Maybe HostName -- ^ host name to look up
--            -> Maybe ServiceName -- ^ service name to look up
--            -> IO [AddrInfo] -- ^ resolved addresses, with "best" first
--
++niFlagMapping = [(NI_DGRAM, 0),
++                 (NI_NAMEREQD, 1),
++                 (NI_NOFQDN, 2),
++                 (NI_NUMERICHOST, 3),
++                 (NI_NUMERICSERV, 4)]
+ 
+ -- | Default hints for address lookup with 'getAddrInfo'.  The values
+ -- of the 'addrAddress' and 'addrCanonName' fields are 'undefined',
+@@ -1453,58 +1262,30 @@ getAddrInfo :: Maybe AddrInfo -- ^ preferred socket type or protocol
+             -> Maybe ServiceName -- ^ service name to look up
+             -> IO [AddrInfo] -- ^ resolved addresses, with "best" first
+ 
 -getAddrInfo hints node service = withSocketsDo $
 -  maybeWith withCString node $ \c_node ->
 -    maybeWith withCString service $ \c_service ->
@@ -4167,31 +1265,46 @@ index 6a1ce6a..0000000
 -#else
 -gai_strerror n = ioError $ userError $ "Network.Socket.gai_strerror not supported: " ++ show n
 -#endif
--
--withCStringIf :: Bool -> Int -> (CSize -> CString -> IO a) -> IO a
--withCStringIf False _ f = f 0 nullPtr
--withCStringIf True n f = allocaBytes n (f (fromIntegral n))
--
---- | Resolve an address to a host or service name.
---- This function is protocol independent.
---- The list of 'NameInfoFlag' values controls query behaviour.
----
---- If a host or service's name cannot be looked up, then the numeric
---- form of the address or service will be returned.
----
---- If the query fails, this function throws an IO exception.
----
---- Example:
---- @
----   (hostName, _) <- getNameInfo [] True False myAddress
---- @
--
--getNameInfo :: [NameInfoFlag] -- ^ flags to control lookup behaviour
--            -> Bool -- ^ whether to look up a hostname
--            -> Bool -- ^ whether to look up a service name
--            -> SockAddr -- ^ the address to look up
--            -> IO (Maybe HostName, Maybe ServiceName)
--
++getAddrInfo mHints node service = withSocketsDo $ do
++  addresses <- c_getaddrinfo (fromMaybe "0.0.0.0" node)
++  return $ map toAddrInfo $ filter filterFun $ fromJava addresses
++  where toAddrInfo inetAddr = defaultHints {
++          addrAddress    = SockAddrInet port (inetAddrInt inetAddr),
++          addrSocketType = maybe (addrSocketType defaultHints) addrSocketType mHints,
++          addrFamily     = if isIPv6 inetAddr then AF_INET6 else AF_INET
++          }
++        filterFun  =
++          case addrFamilySelect of
++            AF_INET  -> not . isIPv6
++            AF_INET6 -> isIPv6
++            _        -> const True
++        addrFamilySelect = maybe (addrFamily defaultHints) addrFamily mHints
++        port
++          | Just port' <- service
++          = read port'
++          | otherwise = 0
++
++foreign import CALLCONV unsafe "@static java.net.InetAddress.getAllByName"
++  c_getaddrinfo :: String -> IO InetAddressArray
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.isIPv6"
++  isIPv6 :: InetAddress -> Bool
+ 
+ withCStringIf :: Bool -> Int -> (CSize -> CString -> IO a) -> IO a
+ withCStringIf False _ f = f 0 nullPtr
+@@ -1524,34 +1305,31 @@ withCStringIf True n f = allocaBytes n (f (fromIntegral n))
+ --   (hostName, _) <- getNameInfo [] True False myAddress
+ -- @
+ 
++foreign import CALLCONV unsafe "@static eta.network.Utils.inet6_ntoa"
++  inet6_ntoa :: JIntArray -> String
++
+ getNameInfo :: [NameInfoFlag] -- ^ flags to control lookup behaviour
+             -> Bool -- ^ whether to look up a hostname
+             -> Bool -- ^ whether to look up a service name
+             -> SockAddr -- ^ the address to look up
+             -> IO (Maybe HostName, Maybe ServiceName)
+ 
 -getNameInfo flags doHost doService addr = withSocketsDo $
 -  withCStringIf doHost (#const NI_MAXHOST) $ \c_hostlen c_host ->
 -    withCStringIf doService (#const NI_MAXSERV) $ \c_servlen c_serv -> do
@@ -4214,31 +1327,88 @@ index 6a1ce6a..0000000
 -foreign import ccall safe "hsnet_getnameinfo"
 -    c_getnameinfo :: Ptr SockAddr -> CInt{-CSockLen???-} -> CString -> CSize -> CString
 -                  -> CSize -> CInt -> IO CInt
--#endif
--
--mkInvalidRecvArgError :: String -> IOError
--mkInvalidRecvArgError loc = ioeSetErrorString (mkIOError
--                                    InvalidArgument
--                                    loc Nothing Nothing) "non-positive length"
--
--mkEOFError :: String -> IOError
--mkEOFError loc = ioeSetErrorString (mkIOError EOF loc Nothing Nothing) "end of file"
--
---- ---------------------------------------------------------------------------
---- foreign imports from the C library
--
++getNameInfo _flags _doHost _doService addr =
++  case addr of
++    SockAddrInet6 _ _ addr _ -> do
++      let (ip1,ip2,ip3,ip4) = addr
++      hostName <- c_getnameinfo $ toJByteArray (concatMap word32to8 [ip1,ip2,ip3,ip4])
++      return (Just hostName, Nothing)
++    SockAddrInet _ addr -> do
++      hostName <- c_getnameinfo $ toJByteArray (word32to8 addr)
++      return (Just hostName, Nothing)
++  where word32to8 w32 = map fromIntegral [(w32 `shiftR` 24) .&. 0xFF
++                                         ,(w32 `shiftR` 16) .&. 0xFF
++                                         ,(w32 `shiftR` 8)  .&. 0xFF
++                                         ,w32 .&. 0xFF]
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.getNameInfo"
++  c_getnameinfo :: JByteArray -> IO String
+ #endif
+ 
+ mkInvalidRecvArgError :: String -> IOError
+@@ -1565,71 +1343,101 @@ mkEOFError loc = ioeSetErrorString (mkIOError EOF loc Nothing Nothing) "end of f
+ -- ---------------------------------------------------------------------------
+ -- foreign imports from the C library
+ 
 -foreign import ccall unsafe "hsnet_inet_ntoa"
 -  c_inet_ntoa :: HostAddress -> IO (Ptr CChar)
--
++foreign import CALLCONV unsafe "@static eta.network.Utils.inet_ntoa"
++  c_inet_ntoa :: HostAddress -> IO String
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.inet_addr"
++  c_inet_addr :: String -> IO HostAddress
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.shutdown"
++  c_shutdown :: Channel -> CInt -> IO CInt
++
++closeFd :: Channel -> IO ()
++closeFd fd = c_close fd
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.socket"
++  c_socket :: CInt -> CInt -> CInt -> IO Channel
++foreign import CALLCONV unsafe "@static eta.network.Utils.bind"
++  c_bind :: Channel -> SocketAddress -> IO CInt
++foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.connect"
++  c_connect :: Channel -> SocketAddress -> IO Bool
++foreign import CALLCONV unsafe "@static eta.network.Utils.accept"
++  c_accept :: Channel -> IO (Maybe Channel)
++foreign import CALLCONV unsafe "@static eta.network.Utils.listen"
++  c_listen :: Channel -> SocketAddress -> CInt -> IO CInt
++
++-- foreign import CALLCONV unsafe "send"
++--   c_send :: CInt -> Ptr a -> CSize -> CInt -> IO CInt
++foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.sendto"
++  c_sendto :: Channel -> Ptr a -> CSize -> SocketAddress -> IO CInt
++-- foreign import CALLCONV unsafe "recv"
++--   c_recv :: CInt -> Ptr CChar -> CSize -> CInt -> IO CInt
++-- foreign import CALLCONV SAFE_ON_WIN "@static eta.network.Utils.sendto"
++--   c_recvfrom :: CInt -> Ptr a -> CSize -> CInt -> Ptr SockAddr -> IO CInt
++-- foreign import CALLCONV unsafe "getpeername"
++--   c_getpeername :: CInt -> Ptr SockAddr -> Ptr CInt -> IO CInt
++-- foreign import CALLCONV unsafe "getsockname"
++--   c_getsockname :: CInt -> Ptr SockAddr -> Ptr CInt -> IO CInt
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.getsockopt"
++  c_getsockopt :: Channel -> SOption -> IO CInt
++foreign import CALLCONV unsafe "@static eta.network.Utils.setsockopt"
++  c_setsockopt :: Channel -> SOption -> CInt ->  IO ()
+ 
 -foreign import CALLCONV unsafe "inet_addr"
 -  c_inet_addr :: Ptr CChar -> IO HostAddress
--
++#if defined(HAVE_GETPEEREID)
++foreign import CALLCONV unsafe "getpeereid"
++  c_getpeereid :: CInt -> Ptr CUInt -> Ptr CUInt -> IO CInt
++#endif
+ 
 -foreign import CALLCONV unsafe "shutdown"
 -  c_shutdown :: CInt -> CInt -> IO CInt
--
++foreign import CALLCONV unsafe "@static eta.network.Utils.isBlocking" isBlocking
++  :: Channel -> IO Bool
+ 
 -closeFd :: CInt -> IO ()
 -closeFd fd = throwSocketErrorIfMinus1_ "Network.Socket.close" $ c_close fd
--
++data {-# CLASS "java.net.SocketOption" #-} SOption = SOption (Object# SOption)
+ 
 -#if !defined(WITH_WINSOCK)
 -foreign import ccall unsafe "close"
 -  c_close :: CInt -> IO CInt
@@ -4246,7 +1416,10 @@ index 6a1ce6a..0000000
 -foreign import stdcall unsafe "closesocket"
 -  c_close :: CInt -> IO CInt
 -#endif
--
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_IF"
++  iP_MULTICAST_IF :: SOption
+ 
 -foreign import CALLCONV unsafe "socket"
 -  c_socket :: CInt -> CInt -> CInt -> IO CInt
 -foreign import CALLCONV unsafe "bind"
@@ -4262,14 +1435,23 @@ index 6a1ce6a..0000000
 -#endif
 -foreign import CALLCONV unsafe "listen"
 -  c_listen :: CInt -> CInt -> IO CInt
--
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_LOOP"
++  iP_MULTICAST_LOOP :: SOption
+ 
 -#if defined(mingw32_HOST_OS)
 -foreign import CALLCONV safe "accept"
 -  c_accept_safe :: CInt -> Ptr SockAddr -> Ptr CInt{-CSockLen???-} -> IO CInt
--
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.IP_MULTICAST_TTL"
++  iP_MULTICAST_TTL :: SOption
+ 
 -foreign import ccall unsafe "rtsSupportsBoundThreads" threaded :: Bool
 -#endif
--
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.IP_TOS"
++  iP_TOS :: SOption
+ 
 -foreign import CALLCONV unsafe "send"
 -  c_send :: CInt -> Ptr a -> CSize -> CInt -> IO CInt
 -foreign import CALLCONV SAFE_ON_WIN "sendto"
@@ -4287,398 +1469,52 @@ index 6a1ce6a..0000000
 -  c_getsockopt :: CInt -> CInt -> CInt -> Ptr CInt -> Ptr CInt -> IO CInt
 -foreign import CALLCONV unsafe "setsockopt"
 -  c_setsockopt :: CInt -> CInt -> CInt -> Ptr CInt -> CInt -> IO CInt
--
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_BROADCAST"
++  sO_BROADCAST :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_KEEPALIVE"
++  sO_KEEPALIVE :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_LINGER"
++  sO_LINGER :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_RCVBUF"
++  sO_RCVBUF :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_REUSEADDR"
++  sO_REUSEADDR :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.SO_SNDBUF"
++  sO_SNDBUF :: SOption
++
++foreign import java unsafe
++  "@static @field java.net.StandardSocketOptions.TCP_NODELAY"
++  tCP_NODELAY :: SOption
+ 
 -#if defined(HAVE_GETPEEREID)
 -foreign import CALLCONV unsafe "getpeereid"
 -  c_getpeereid :: CInt -> Ptr CUInt -> Ptr CUInt -> IO CInt
 -#endif
---- ---------------------------------------------------------------------------
---- * Deprecated aliases
--
---- $deprecated-aliases
----
---- These aliases are deprecated and should not be used in new code.
---- They will be removed in some future version of the package.
--
--{-# DEPRECATED bindSocket "use 'bind'" #-}
--
---- | Deprecated alias for 'bind'.
--bindSocket :: Socket    -- Unconnected Socket
--           -> SockAddr  -- Address to Bind to
--           -> IO ()
--bindSocket = bind
--
--{-# DEPRECATED sClose "use 'close'" #-}
--
---- | Deprecated alias for 'close'.
--sClose :: Socket -> IO ()
--sClose = close
--
--{-# DEPRECATED sIsConnected "use 'isConnected'" #-}
--
---- | Deprecated alias for 'isConnected'.
--sIsConnected :: Socket -> IO Bool
--sIsConnected = isConnected
--
--{-# DEPRECATED sIsBound "use 'isBound'" #-}
--
---- | Deprecated alias for 'isBound'.
--sIsBound :: Socket -> IO Bool
--sIsBound = isBound
--
--{-# DEPRECATED sIsListening "use 'isListening'" #-}
--
---- | Deprecated alias for 'isListening'.
--sIsListening :: Socket -> IO Bool
--sIsListening = isListening
--
--{-# DEPRECATED sIsReadable "use 'isReadable'" #-}
--
---- | Deprecated alias for 'isReadable'.
--sIsReadable  :: Socket -> IO Bool
--sIsReadable = isReadable
--
--{-# DEPRECATED sIsWritable "use 'isWritable'" #-}
--
---- | Deprecated alias for 'isWritable'.
--sIsWritable  :: Socket -> IO Bool
--sIsWritable = isWritable
-diff --git a/Network/Socket/ByteString.hs b/Network/Socket/ByteString.hs
-new file mode 100644
-index 0000000..dcc7a21
---- /dev/null
-+++ b/Network/Socket/ByteString.hs
-@@ -0,0 +1,263 @@
-+{-# LANGUAGE CPP, ForeignFunctionInterface #-}
-+
-+#include "HsNet.h"
-+
-+-- |
-+-- Module      : Network.Socket.ByteString
-+-- Copyright   : (c) Johan Tibell 2007-2010
-+-- License     : BSD-style
-+--
-+-- Maintainer  : johan.tibell@gmail.com
-+-- Stability   : stable
-+-- Portability : portable
-+--
-+-- This module provides access to the BSD /socket/ interface.  This
-+-- module is generally more efficient than the 'String' based network
-+-- functions in 'Network.Socket'.  For detailed documentation, consult
-+-- your favorite POSIX socket reference. All functions communicate
-+-- failures by converting the error number to 'System.IO.IOError'.
-+--
-+-- This module is made to be imported with 'Network.Socket' like so:
-+--
-+-- > import Network.Socket hiding (send, sendTo, recv, recvFrom)
-+-- > import Network.Socket.ByteString
-+--
-+module Network.Socket.ByteString
-+    (
-+    -- * Send data to a socket
-+      send
-+    , sendAll
-+    , sendTo
-+    , sendAllTo
-+
-+    -- ** Vectored I/O
-+    -- $vectored
-+    , sendMany
-+    , sendManyTo
-+
-+    -- * Receive data from a socket
-+    , recv
-+    , recvFrom
-+
-+    -- * Example
-+    -- $example
-+    ) where
-+
-+import Control.Exception (catch, throwIO)
-+import Control.Monad (when)
-+import Data.ByteString (ByteString)
-+import Data.ByteString.Internal (createAndTrim)
-+import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
-+import Foreign.Marshal.Alloc (allocaBytes)
-+import Foreign.Ptr (castPtr)
-+import Network.Socket (sendBuf, sendBufTo, recvBuf, recvBufFrom)
-+import System.IO.Error (isEOFError)
-+
-+import qualified Data.ByteString as B
-+
-+import Network.Socket.ByteString.Internal
-+import Network.Socket.Internal
-+import Network.Socket.Types
-+
-+-- ----------------------------------------------------------------------------
-+-- Sending
-+
-+-- | Send data to the socket.  The socket must be connected to a
-+-- remote socket.  Returns the number of bytes sent. Applications are
-+-- responsible for ensuring that all data has been sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+send :: Socket      -- ^ Connected socket
-+     -> ByteString  -- ^ Data to send
-+     -> IO Int      -- ^ Number of bytes sent
-+send sock xs = unsafeUseAsCStringLen xs $ \(str, len) ->
-+    sendBuf sock (castPtr str) len
-+
-+-- | Send data to the socket.  The socket must be connected to a
-+-- remote socket.  Unlike 'send', this function continues to send data
-+-- until either all data has been sent or an error occurs.  On error,
-+-- an exception is raised, and there is no way to determine how much
-+-- data, if any, was successfully sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendAll :: Socket      -- ^ Connected socket
-+        -> ByteString  -- ^ Data to send
-+        -> IO ()
-+sendAll sock bs = do
-+    sent <- send sock bs
-+    when (sent < B.length bs) $ sendAll sock (B.drop sent bs)
-+
-+-- | Send data to the socket.  The recipient can be specified
-+-- explicitly, so the socket need not be in a connected state.
-+-- Returns the number of bytes sent. Applications are responsible for
-+-- ensuring that all data has been sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendTo :: Socket      -- ^ Socket
-+       -> ByteString  -- ^ Data to send
-+       -> SockAddr    -- ^ Recipient address
-+       -> IO Int      -- ^ Number of bytes sent
-+sendTo sock xs addr =
-+    unsafeUseAsCStringLen xs $ \(str, len) -> sendBufTo sock str len addr
-+
-+-- | Send data to the socket. The recipient can be specified
-+-- explicitly, so the socket need not be in a connected state.  Unlike
-+-- 'sendTo', this function continues to send data until either all
-+-- data has been sent or an error occurs.  On error, an exception is
-+-- raised, and there is no way to determine how much data, if any, was
-+-- successfully sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendAllTo :: Socket      -- ^ Socket
-+          -> ByteString  -- ^ Data to send
-+          -> SockAddr    -- ^ Recipient address
-+          -> IO ()
-+sendAllTo sock xs addr = do
-+    sent <- sendTo sock xs addr
-+    when (sent < B.length xs) $ sendAllTo sock (B.drop sent xs) addr
-+
-+-- ----------------------------------------------------------------------------
-+-- ** Vectored I/O
-+
-+-- $vectored
-+--
-+-- Vectored I\/O, also known as scatter\/gather I\/O, allows multiple
-+-- data segments to be sent using a single system call, without first
-+-- concatenating the segments.  For example, given a list of
-+-- @ByteString@s, @xs@,
-+--
-+-- > sendMany sock xs
-+--
-+-- is equivalent to
-+--
-+-- > sendAll sock (concat xs)
-+--
-+-- but potentially more efficient.
-+--
-+-- Vectored I\/O are often useful when implementing network protocols
-+-- that, for example, group data into segments consisting of one or
-+-- more fixed-length headers followed by a variable-length body.
-+
-+-- | Send data to the socket.  The socket must be in a connected
-+-- state.  The data is sent as if the parts have been concatenated.
-+-- This function continues to send data until either all data has been
-+-- sent or an error occurs.  On error, an exception is raised, and
-+-- there is no way to determine how much data, if any, was
-+-- successfully sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendMany :: Socket        -- ^ Connected socket
-+         -> [ByteString]  -- ^ Data to send
-+         -> IO ()
-+sendMany sock = sendAll sock . B.concat
-+
-+-- | Send data to the socket.  The recipient can be specified
-+-- explicitly, so the socket need not be in a connected state.  The
-+-- data is sent as if the parts have been concatenated.  This function
-+-- continues to send data until either all data has been sent or an
-+-- error occurs.  On error, an exception is raised, and there is no
-+-- way to determine how much data, if any, was successfully sent.
-+--
-+-- Sending data to closed socket may lead to undefined behaviour.
-+sendManyTo :: Socket        -- ^ Socket
-+           -> [ByteString]  -- ^ Data to send
-+           -> SockAddr      -- ^ Recipient address
-+           -> IO ()
-+sendManyTo sock cs = sendAllTo sock (B.concat cs)
-+
-+-- ----------------------------------------------------------------------------
-+-- Receiving
-+
-+-- | Receive data from the socket.  The socket must be in a connected
-+-- state.  This function may return fewer bytes than specified.  If
-+-- the message is longer than the specified length, it may be
-+-- discarded depending on the type of socket.  This function may block
-+-- until a message arrives.
-+--
-+-- Considering hardware and network realities, the maximum number of bytes to
-+-- receive should be a small power of 2, e.g., 4096.
-+--
-+-- For TCP sockets, a zero length return value means the peer has
-+-- closed its half side of the connection.
-+--
-+-- Receiving data from closed socket may lead to undefined behaviour.
-+recv :: Socket         -- ^ Connected socket
-+     -> Int            -- ^ Maximum number of bytes to receive
-+     -> IO ByteString  -- ^ Data received
-+recv sock nbytes
-+    | nbytes < 0 = ioError (mkInvalidRecvArgError "Network.Socket.ByteString.recv")
-+    | otherwise  = createAndTrim nbytes $ \ptr ->
-+        catch
-+          (recvBuf sock ptr nbytes)
-+          (\e -> if isEOFError e then return 0 else throwIO e)
-+
-+-- | Receive data from the socket.  The socket need not be in a
-+-- connected state.  Returns @(bytes, address)@ where @bytes@ is a
-+-- 'ByteString' representing the data received and @address@ is a
-+-- 'SockAddr' representing the address of the sending socket.
-+--
-+-- Receiving data from closed socket may lead to undefined behaviour.
-+recvFrom :: Socket                     -- ^ Socket
-+         -> Int                        -- ^ Maximum number of bytes to receive
-+         -> IO (ByteString, SockAddr)  -- ^ Data received and sender address
-+recvFrom sock nbytes =
-+    allocaBytes nbytes $ \ptr -> do
-+        (len, sockaddr) <- recvBufFrom sock ptr nbytes
-+        str <- B.packCStringLen (ptr, len)
-+        return (str, sockaddr)
-+
-+-- ---------------------------------------------------------------------
-+-- Example
-+
-+-- $example
-+--
-+-- Here are two minimal example programs using the TCP/IP protocol: a
-+-- server that echoes all data that it receives back (servicing only
-+-- one client) and a client using it.
-+--
-+-- > -- Echo server program
-+-- > module Main where
-+-- >
-+-- > import Control.Monad (unless)
-+-- > import Network.Socket hiding (recv)
-+-- > import qualified Data.ByteString as S
-+-- > import Network.Socket.ByteString (recv, sendAll)
-+-- >
-+-- > main :: IO ()
-+-- > main = withSocketsDo $
-+-- >     do addrinfos <- getAddrInfo
-+-- >                     (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
-+-- >                     Nothing (Just "3000")
-+-- >        let serveraddr = head addrinfos
-+-- >        sock <- socket (addrFamily serveraddr) Stream defaultProtocol
-+-- >        bind sock (addrAddress serveraddr)
-+-- >        listen sock 1
-+-- >        (conn, _) <- accept sock
-+-- >        talk conn
-+-- >        close conn
-+-- >        close sock
-+-- >
-+-- >     where
-+-- >       talk :: Socket -> IO ()
-+-- >       talk conn =
-+-- >           do msg <- recv conn 1024
-+-- >              unless (S.null msg) $ sendAll conn msg >> talk conn
-+--
-+-- > -- Echo client program
-+-- > module Main where
-+-- >
-+-- > import Network.Socket hiding (recv)
-+-- > import Network.Socket.ByteString (recv, sendAll)
-+-- > import qualified Data.ByteString.Char8 as C
-+-- >
-+-- > main :: IO ()
-+-- > main = withSocketsDo $
-+-- >     do addrinfos <- getAddrInfo Nothing (Just "") (Just "3000")
-+-- >        let serveraddr = head addrinfos
-+-- >        sock <- socket (addrFamily serveraddr) Stream defaultProtocol
-+-- >        connect sock (addrAddress serveraddr)
-+-- >        sendAll sock $ C.pack "Hello, world!"
-+-- >        msg <- recv sock 1024
-+-- >        close sock
-+-- >        putStr "Received "
-+-- >        C.putStrLn msg
-diff --git a/Network/Socket/ByteString.hsc b/Network/Socket/ByteString.hsc
-deleted file mode 100644
-index 2745bfd..0000000
+ -- ---------------------------------------------------------------------------
+ -- * Deprecated aliases
+ 
+diff --git a/Network/Socket/ByteString.hsc b/Network/Socket/ByteString.hs
+similarity index 77%
+rename from Network/Socket/ByteString.hsc
+rename to Network/Socket/ByteString.hs
+index 2745bfd..dcc7a21 100644
 --- a/Network/Socket/ByteString.hsc
-+++ /dev/null
-@@ -1,338 +0,0 @@
--{-# LANGUAGE CPP, ForeignFunctionInterface #-}
--
--#include "HsNet.h"
--
---- |
---- Module      : Network.Socket.ByteString
---- Copyright   : (c) Johan Tibell 2007-2010
---- License     : BSD-style
----
---- Maintainer  : johan.tibell@gmail.com
---- Stability   : stable
---- Portability : portable
----
---- This module provides access to the BSD /socket/ interface.  This
---- module is generally more efficient than the 'String' based network
---- functions in 'Network.Socket'.  For detailed documentation, consult
---- your favorite POSIX socket reference. All functions communicate
---- failures by converting the error number to 'System.IO.IOError'.
----
---- This module is made to be imported with 'Network.Socket' like so:
----
---- > import Network.Socket hiding (send, sendTo, recv, recvFrom)
---- > import Network.Socket.ByteString
----
--module Network.Socket.ByteString
--    (
--    -- * Send data to a socket
--      send
--    , sendAll
--    , sendTo
--    , sendAllTo
--
--    -- ** Vectored I/O
--    -- $vectored
--    , sendMany
--    , sendManyTo
--
--    -- * Receive data from a socket
--    , recv
--    , recvFrom
--
--    -- * Example
--    -- $example
--    ) where
--
--import Control.Exception (catch, throwIO)
--import Control.Monad (when)
--import Data.ByteString (ByteString)
--import Data.ByteString.Internal (createAndTrim)
--import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
--import Foreign.Marshal.Alloc (allocaBytes)
--import Foreign.Ptr (castPtr)
--import Network.Socket (sendBuf, sendBufTo, recvBuf, recvBufFrom)
--import System.IO.Error (isEOFError)
--
--import qualified Data.ByteString as B
--
--import Network.Socket.ByteString.Internal
--import Network.Socket.Internal
--import Network.Socket.Types
--
++++ b/Network/Socket/ByteString.hs
+@@ -59,17 +59,6 @@ import Network.Socket.ByteString.Internal
+ import Network.Socket.Internal
+ import Network.Socket.Types
+ 
 -#if !defined(mingw32_HOST_OS)
 -import Control.Monad (liftM, zipWithM_)
 -import Foreign.Marshal.Array (allocaArray)
@@ -4690,96 +1526,13 @@ index 2745bfd..0000000
 -import Network.Socket.ByteString.MsgHdr (MsgHdr(..))
 -#endif
 -
---- ----------------------------------------------------------------------------
---- Sending
--
---- | Send data to the socket.  The socket must be connected to a
---- remote socket.  Returns the number of bytes sent. Applications are
---- responsible for ensuring that all data has been sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--send :: Socket      -- ^ Connected socket
--     -> ByteString  -- ^ Data to send
--     -> IO Int      -- ^ Number of bytes sent
--send sock xs = unsafeUseAsCStringLen xs $ \(str, len) ->
--    sendBuf sock (castPtr str) len
--
---- | Send data to the socket.  The socket must be connected to a
---- remote socket.  Unlike 'send', this function continues to send data
---- until either all data has been sent or an error occurs.  On error,
---- an exception is raised, and there is no way to determine how much
---- data, if any, was successfully sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendAll :: Socket      -- ^ Connected socket
--        -> ByteString  -- ^ Data to send
--        -> IO ()
--sendAll sock bs = do
--    sent <- send sock bs
--    when (sent < B.length bs) $ sendAll sock (B.drop sent bs)
--
---- | Send data to the socket.  The recipient can be specified
---- explicitly, so the socket need not be in a connected state.
---- Returns the number of bytes sent. Applications are responsible for
---- ensuring that all data has been sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendTo :: Socket      -- ^ Socket
--       -> ByteString  -- ^ Data to send
--       -> SockAddr    -- ^ Recipient address
--       -> IO Int      -- ^ Number of bytes sent
--sendTo sock xs addr =
--    unsafeUseAsCStringLen xs $ \(str, len) -> sendBufTo sock str len addr
--
---- | Send data to the socket. The recipient can be specified
---- explicitly, so the socket need not be in a connected state.  Unlike
---- 'sendTo', this function continues to send data until either all
---- data has been sent or an error occurs.  On error, an exception is
---- raised, and there is no way to determine how much data, if any, was
---- successfully sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendAllTo :: Socket      -- ^ Socket
--          -> ByteString  -- ^ Data to send
--          -> SockAddr    -- ^ Recipient address
--          -> IO ()
--sendAllTo sock xs addr = do
--    sent <- sendTo sock xs addr
--    when (sent < B.length xs) $ sendAllTo sock (B.drop sent xs) addr
--
---- ----------------------------------------------------------------------------
---- ** Vectored I/O
--
---- $vectored
----
---- Vectored I\/O, also known as scatter\/gather I\/O, allows multiple
---- data segments to be sent using a single system call, without first
---- concatenating the segments.  For example, given a list of
---- @ByteString@s, @xs@,
----
---- > sendMany sock xs
----
---- is equivalent to
----
---- > sendAll sock (concat xs)
----
---- but potentially more efficient.
----
---- Vectored I\/O are often useful when implementing network protocols
---- that, for example, group data into segments consisting of one or
---- more fixed-length headers followed by a variable-length body.
--
---- | Send data to the socket.  The socket must be in a connected
---- state.  The data is sent as if the parts have been concatenated.
---- This function continues to send data until either all data has been
---- sent or an error occurs.  On error, an exception is raised, and
---- there is no way to determine how much data, if any, was
---- successfully sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendMany :: Socket        -- ^ Connected socket
--         -> [ByteString]  -- ^ Data to send
--         -> IO ()
+ -- ----------------------------------------------------------------------------
+ -- Sending
+ 
+@@ -160,19 +149,7 @@ sendAllTo sock xs addr = do
+ sendMany :: Socket        -- ^ Connected socket
+          -> [ByteString]  -- ^ Data to send
+          -> IO ()
 -#if !defined(mingw32_HOST_OS)
 -sendMany sock@(MkSocket fd _ _ _ _) cs = do
 -    sent <- sendManyInner
@@ -4791,21 +1544,15 @@ index 2745bfd..0000000
 -              c_writev (fromIntegral fd) iovsPtr
 -              (fromIntegral (min iovsLen (#const IOV_MAX)))
 -#else
--sendMany sock = sendAll sock . B.concat
+ sendMany sock = sendAll sock . B.concat
 -#endif
--
---- | Send data to the socket.  The recipient can be specified
---- explicitly, so the socket need not be in a connected state.  The
---- data is sent as if the parts have been concatenated.  This function
---- continues to send data until either all data has been sent or an
---- error occurs.  On error, an exception is raised, and there is no
---- way to determine how much data, if any, was successfully sent.
----
---- Sending data to closed socket may lead to undefined behaviour.
--sendManyTo :: Socket        -- ^ Socket
--           -> [ByteString]  -- ^ Data to send
--           -> SockAddr      -- ^ Recipient address
--           -> IO ()
+ 
+ -- | Send data to the socket.  The recipient can be specified
+ -- explicitly, so the socket need not be in a connected state.  The
+@@ -186,23 +163,7 @@ sendManyTo :: Socket        -- ^ Socket
+            -> [ByteString]  -- ^ Data to send
+            -> SockAddr      -- ^ Recipient address
+            -> IO ()
 -#if !defined(mingw32_HOST_OS)
 -sendManyTo sock@(MkSocket fd _ _ _ _) cs addr = do
 -    sent <- liftM fromIntegral sendManyToInner
@@ -4821,50 +1568,15 @@ index 2745bfd..0000000
 -            throwSocketErrorWaitWrite sock "Network.Socket.ByteString.sendManyTo" $
 -              c_sendmsg (fromIntegral fd) msgHdrPtr 0
 -#else
--sendManyTo sock cs = sendAllTo sock (B.concat cs)
+ sendManyTo sock cs = sendAllTo sock (B.concat cs)
 -#endif
--
---- ----------------------------------------------------------------------------
---- Receiving
--
---- | Receive data from the socket.  The socket must be in a connected
---- state.  This function may return fewer bytes than specified.  If
---- the message is longer than the specified length, it may be
---- discarded depending on the type of socket.  This function may block
---- until a message arrives.
----
---- Considering hardware and network realities, the maximum number of bytes to
---- receive should be a small power of 2, e.g., 4096.
----
---- For TCP sockets, a zero length return value means the peer has
---- closed its half side of the connection.
----
---- Receiving data from closed socket may lead to undefined behaviour.
--recv :: Socket         -- ^ Connected socket
--     -> Int            -- ^ Maximum number of bytes to receive
--     -> IO ByteString  -- ^ Data received
--recv sock nbytes
--    | nbytes < 0 = ioError (mkInvalidRecvArgError "Network.Socket.ByteString.recv")
--    | otherwise  = createAndTrim nbytes $ \ptr ->
--        catch
--          (recvBuf sock ptr nbytes)
--          (\e -> if isEOFError e then return 0 else throwIO e)
--
---- | Receive data from the socket.  The socket need not be in a
---- connected state.  Returns @(bytes, address)@ where @bytes@ is a
---- 'ByteString' representing the data received and @address@ is a
---- 'SockAddr' representing the address of the sending socket.
----
---- Receiving data from closed socket may lead to undefined behaviour.
--recvFrom :: Socket                     -- ^ Socket
--         -> Int                        -- ^ Maximum number of bytes to receive
--         -> IO (ByteString, SockAddr)  -- ^ Data received and sender address
--recvFrom sock nbytes =
--    allocaBytes nbytes $ \ptr -> do
--        (len, sockaddr) <- recvBufFrom sock ptr nbytes
--        str <- B.packCStringLen (ptr, len)
--        return (str, sockaddr)
--
+ 
+ -- ----------------------------------------------------------------------------
+ -- Receiving
+@@ -245,42 +206,6 @@ recvFrom sock nbytes =
+         str <- B.packCStringLen (ptr, len)
+         return (str, sockaddr)
+ 
 --- ----------------------------------------------------------------------------
 --- Not exported
 -
@@ -4901,61 +1613,9 @@ index 2745bfd..0000000
 -        poke ptr $ IOVec sPtr (fromIntegral sLen)
 -#endif
 -
---- ---------------------------------------------------------------------
---- Example
--
---- $example
----
---- Here are two minimal example programs using the TCP/IP protocol: a
---- server that echoes all data that it receives back (servicing only
---- one client) and a client using it.
----
---- > -- Echo server program
---- > module Main where
---- >
---- > import Control.Monad (unless)
---- > import Network.Socket hiding (recv)
---- > import qualified Data.ByteString as S
---- > import Network.Socket.ByteString (recv, sendAll)
---- >
---- > main :: IO ()
---- > main = withSocketsDo $
---- >     do addrinfos <- getAddrInfo
---- >                     (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
---- >                     Nothing (Just "3000")
---- >        let serveraddr = head addrinfos
---- >        sock <- socket (addrFamily serveraddr) Stream defaultProtocol
---- >        bind sock (addrAddress serveraddr)
---- >        listen sock 1
---- >        (conn, _) <- accept sock
---- >        talk conn
---- >        close conn
---- >        close sock
---- >
---- >     where
---- >       talk :: Socket -> IO ()
---- >       talk conn =
---- >           do msg <- recv conn 1024
---- >              unless (S.null msg) $ sendAll conn msg >> talk conn
----
---- > -- Echo client program
---- > module Main where
---- >
---- > import Network.Socket hiding (recv)
---- > import Network.Socket.ByteString (recv, sendAll)
---- > import qualified Data.ByteString.Char8 as C
---- >
---- > main :: IO ()
---- > main = withSocketsDo $
---- >     do addrinfos <- getAddrInfo Nothing (Just "") (Just "3000")
---- >        let serveraddr = head addrinfos
---- >        sock <- socket (addrFamily serveraddr) Stream defaultProtocol
---- >        connect sock (addrAddress serveraddr)
---- >        sendAll sock $ C.pack "Hello, world!"
---- >        msg <- recv sock 1024
---- >        close sock
---- >        putStr "Received "
---- >        C.putStrLn msg
+ -- ---------------------------------------------------------------------
+ -- Example
+ 
 diff --git a/Network/Socket/ByteString/Internal.hs b/Network/Socket/ByteString/Internal.hs
 index 7aad1a6..2eea992 100644
 --- a/Network/Socket/ByteString/Internal.hs
@@ -5011,613 +1671,79 @@ index e586943..01fd253 100644
  
  -- -----------------------------------------------------------------------------
  -- Receiving
-diff --git a/Network/Socket/Internal.hs b/Network/Socket/Internal.hs
-new file mode 100644
-index 0000000..43be9db
---- /dev/null
+diff --git a/Network/Socket/Internal.hsc b/Network/Socket/Internal.hs
+similarity index 95%
+rename from Network/Socket/Internal.hsc
+rename to Network/Socket/Internal.hs
+index 1372b25..43be9db 100644
+--- a/Network/Socket/Internal.hsc
 +++ b/Network/Socket/Internal.hs
-@@ -0,0 +1,268 @@
-+{-# LANGUAGE CPP #-}
-+{-# LANGUAGE ForeignFunctionInterface #-}
-+{-# OPTIONS_GHC -fno-warn-orphans #-}
-+-----------------------------------------------------------------------------
-+-- |
-+-- Module      :  Network.Socket.Internal
-+-- Copyright   :  (c) The University of Glasgow 2001
-+-- License     :  BSD-style (see the file libraries/network/LICENSE)
-+--
-+-- Maintainer  :  libraries@haskell.org
-+-- Stability   :  provisional
-+-- Portability :  portable
-+--
-+-- A module containing semi-public 'Network.Socket' internals.
-+-- Modules which extend the 'Network.Socket' module will need to use
-+-- this module while ideally most users will be able to make do with
-+-- the public interface.
-+--
-+-----------------------------------------------------------------------------
-+
-+#include "HsNet.h"
-+
-+module Network.Socket.Internal
-+    (
-+    -- * Socket addresses
-+      HostAddress
-+#if defined(IPV6_SOCKET_SUPPORT)
-+    , HostAddress6
-+    , FlowInfo
-+    , ScopeID
-+#endif
-+    , PortNumber(..)
-+    , SockAddr(..)
-+
+@@ -32,12 +32,12 @@ module Network.Socket.Internal
+     , PortNumber(..)
+     , SockAddr(..)
+ 
+-    , peekSockAddr
+-    , pokeSockAddr
+-    , sizeOfSockAddr
+-    , sizeOfSockAddrByFamily
 +    -- , peekSockAddr
 +    -- , pokeSockAddr
 +    -- , sizeOfSockAddr
 +    -- , sizeOfSockAddrByFamily
-+    , withSockAddr
+     , withSockAddr
+-    , withNewSockAddr
 +    -- , withNewSockAddr
-+
-+    -- * Protocol families
-+    , Family(..)
-+
-+    -- * Socket error functions
-+#if defined(HAVE_WINSOCK2_H)
-+    , c_getLastError
-+#endif
-+    , throwSocketError
-+    , throwSocketErrorCode
-+
-+    -- * Guards for socket operations that may fail
-+    , throwSocketErrorIfMinus1_
-+    , throwSocketErrorIfMinus1Retry
-+    , throwSocketErrorIfMinus1Retry_
-+    , throwSocketErrorIfMinus1RetryMayBlock
-+
-+    -- ** Guards that wait and retry if the operation would block
-+    -- | These guards are based on 'throwSocketErrorIfMinus1RetryMayBlock'.
-+    -- They wait for socket readiness if the action fails with @EWOULDBLOCK@
-+    -- or similar.
-+    , throwSocketErrorWaitRead
-+    , throwSocketErrorWaitWrite
-+
-+    -- * Initialization
-+    , withSocketsDo
-+
-+    -- * Low-level helpers
-+    , zeroMemory
-+    ) where
-+
-+import Foreign.C.Error (throwErrno, throwErrnoIfMinus1Retry,
-+                        throwErrnoIfMinus1RetryMayBlock, throwErrnoIfMinus1_,
-+                        Errno(..), errnoToIOError)
-+#if defined(HAVE_WINSOCK2_H)
-+import Foreign.C.String (peekCString)
-+import Foreign.Ptr (Ptr)
-+#endif
-+import Foreign.C.Types (CInt(..))
-+import GHC.Conc (threadWaitRead, threadWaitWrite)
-+
-+#if defined(HAVE_WINSOCK2_H)
-+import Control.Exception ( evaluate )
-+import System.IO.Unsafe ( unsafePerformIO )
-+import Control.Monad ( when )
-+#  if __GLASGOW_HASKELL__ >= 707
-+import GHC.IO.Exception ( IOErrorType(..) )
-+#  else
-+import GHC.IOBase ( IOErrorType(..) )
-+#  endif
-+import Foreign.C.Types ( CChar )
-+import System.IO.Error ( ioeSetErrorString, mkIOError )
-+#endif
-+
-+import Network.Socket.Types
-+
-+-- ---------------------------------------------------------------------
-+-- Guards for socket operations that may fail
-+
-+-- | Throw an 'IOError' corresponding to the current socket error.
-+throwSocketError :: String  -- ^ textual description of the error location
-+                 -> IO a
-+
-+-- | Like 'throwSocketError', but the error code is supplied as an argument.
-+--
-+-- On Windows, do not use errno.  Use a system error code instead.
-+throwSocketErrorCode :: String -> CInt -> IO a
-+
-+-- | Throw an 'IOError' corresponding to the current socket error if
-+-- the IO action returns a result of @-1@.  Discards the result of the
-+-- IO action after error handling.
-+throwSocketErrorIfMinus1_
-+    :: (Eq a, Num a)
-+    => String  -- ^ textual description of the location
-+    -> IO a    -- ^ the 'IO' operation to be executed
-+    -> IO ()
-+
-+{-# SPECIALIZE throwSocketErrorIfMinus1_ :: String -> IO CInt -> IO () #-}
-+
-+-- | Throw an 'IOError' corresponding to the current socket error if
-+-- the IO action returns a result of @-1@, but retries in case of an
-+-- interrupted operation.
-+throwSocketErrorIfMinus1Retry
-+    :: (Eq a, Num a)
-+    => String  -- ^ textual description of the location
-+    -> IO a    -- ^ the 'IO' operation to be executed
-+    -> IO a
-+
-+{-# SPECIALIZE throwSocketErrorIfMinus1Retry :: String -> IO CInt -> IO CInt #-}
-+
-+-- | Throw an 'IOError' corresponding to the current socket error if
-+-- the IO action returns a result of @-1@, but retries in case of an
-+-- interrupted operation. Discards the result of the IO action after
-+-- error handling.
-+throwSocketErrorIfMinus1Retry_
-+    :: (Eq a, Num a)
-+    => String  -- ^ textual description of the location
-+    -> IO a    -- ^ the 'IO' operation to be executed
-+    -> IO ()
-+throwSocketErrorIfMinus1Retry_ loc m =
-+    throwSocketErrorIfMinus1Retry loc m >> return ()
-+{-# SPECIALIZE throwSocketErrorIfMinus1Retry_ :: String -> IO CInt -> IO () #-}
-+
-+-- | Throw an 'IOError' corresponding to the current socket error if
-+-- the IO action returns a result of @-1@, but retries in case of an
-+-- interrupted operation.  Checks for operations that would block and
-+-- executes an alternative action before retrying in that case.
-+throwSocketErrorIfMinus1RetryMayBlock
-+    :: (Eq a, Num a)
-+    => String  -- ^ textual description of the location
-+    -> IO b    -- ^ action to execute before retrying if an
-+               --   immediate retry would block
-+    -> IO a    -- ^ the 'IO' operation to be executed
-+    -> IO a
-+
-+{-# SPECIALIZE throwSocketErrorIfMinus1RetryMayBlock
-+        :: String -> IO b -> IO CInt -> IO CInt #-}
-+
-+#if (!defined(HAVE_WINSOCK2_H))
-+
-+throwSocketErrorIfMinus1RetryMayBlock name on_block act =
-+    throwErrnoIfMinus1RetryMayBlock name act on_block
-+
-+throwSocketErrorIfMinus1Retry = throwErrnoIfMinus1Retry
-+
-+throwSocketErrorIfMinus1_ = throwErrnoIfMinus1_
-+
-+throwSocketError = throwErrno
-+
-+throwSocketErrorCode loc errno =
-+    ioError (errnoToIOError loc (Errno errno) Nothing Nothing)
-+
-+#else
-+
-+throwSocketErrorIfMinus1RetryMayBlock name _ act
-+  = throwSocketErrorIfMinus1Retry name act
-+
-+throwSocketErrorIfMinus1_ name act = do
-+  throwSocketErrorIfMinus1Retry name act
-+  return ()
-+
-+# if defined(HAVE_WINSOCK2_H)
-+throwSocketErrorIfMinus1Retry name act = do
-+  r <- act
-+  if (r == -1)
-+   then do
-+    rc   <- c_getLastError
-+    case rc of
-+      #{const WSANOTINITIALISED} -> do
-+        withSocketsDo (return ())
-+        r <- act
-+        if (r == -1)
-+           then throwSocketError name
-+           else return r
-+      _ -> throwSocketError name
-+   else return r
-+
-+throwSocketErrorCode name rc = do
-+    pstr <- c_getWSError rc
-+    str  <- peekCString pstr
-+    ioError (ioeSetErrorString (mkIOError OtherError name Nothing Nothing) str)
-+
-+throwSocketError name =
-+    c_getLastError >>= throwSocketErrorCode name
-+
-+foreign import CALLCONV unsafe "WSAGetLastError"
-+  c_getLastError :: IO CInt
-+
-+foreign import ccall unsafe "getWSErrorDescr"
-+  c_getWSError :: CInt -> IO (Ptr CChar)
-+
-+
-+# else
-+throwSocketErrorIfMinus1Retry = throwErrnoIfMinus1Retry
-+throwSocketError = throwErrno
-+throwSocketErrorCode loc errno =
-+    ioError (errnoToIOError loc (Errno errno) Nothing Nothing)
-+# endif
-+#endif
-+
-+-- | Like 'throwSocketErrorIfMinus1Retry', but if the action fails with
-+-- @EWOULDBLOCK@ or similar, wait for the socket to be read-ready,
-+-- and try again.
-+throwSocketErrorWaitRead :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+ 
+     -- * Protocol families
+     , Family(..)
+@@ -222,19 +222,13 @@ throwSocketErrorCode loc errno =
+ -- @EWOULDBLOCK@ or similar, wait for the socket to be read-ready,
+ -- and try again.
+ throwSocketErrorWaitRead :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+-throwSocketErrorWaitRead sock name io =
+-    throwSocketErrorIfMinus1RetryMayBlock name
+-        (threadWaitRead $ fromIntegral $ sockFd sock)
+-        io
 +throwSocketErrorWaitRead _sock _name io = io
-+
-+-- | Like 'throwSocketErrorIfMinus1Retry', but if the action fails with
-+-- @EWOULDBLOCK@ or similar, wait for the socket to be write-ready,
-+-- and try again.
-+throwSocketErrorWaitWrite :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+ 
+ -- | Like 'throwSocketErrorIfMinus1Retry', but if the action fails with
+ -- @EWOULDBLOCK@ or similar, wait for the socket to be write-ready,
+ -- and try again.
+ throwSocketErrorWaitWrite :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
+-throwSocketErrorWaitWrite sock name io =
+-    throwSocketErrorIfMinus1RetryMayBlock name
+-        (threadWaitWrite $ fromIntegral $ sockFd sock)
+-        io
 +throwSocketErrorWaitWrite _sock _name io = io
-+
-+-- ---------------------------------------------------------------------------
-+-- WinSock support
-+
-+{-| With older versions of the @network@ library on Windows operating systems,
-+the networking subsystem must be initialised using 'withSocketsDo' before
-+any networking operations can be used. eg.
-+
-+> main = withSocketsDo $ do {...}
-+
-+It is fine to nest calls to 'withSocketsDo', and to perform networking operations
-+after 'withSocketsDo' has returned.
-+
-+In newer versions of the @network@ library it is only necessary to call
-+'withSocketsDo' if you are calling the 'MkSocket' constructor directly.
-+However, for compatibility with older versions on Windows, it is good practice
-+to always call 'withSocketsDo' (it's very cheap).
-+-}
-+{-# INLINE withSocketsDo #-}
-+withSocketsDo :: IO a -> IO a
-+#if !defined(WITH_WINSOCK)
-+withSocketsDo x = x
-+#else
-+withSocketsDo act = evaluate withSocketsInit >> act
-+
-+
-+{-# NOINLINE withSocketsInit #-}
-+withSocketsInit :: ()
-+-- Use a CAF to make forcing it do initialisation once, but subsequent forces will be cheap
-+withSocketsInit = unsafePerformIO $ do
-+    x <- initWinSock
-+    when (x /= 0) $ ioError $
-+      userError "Network.Socket.Internal.withSocketsDo: Failed to initialise WinSock"
-+
-+foreign import ccall unsafe "initWinSock" initWinSock :: IO Int
-+
-+#endif
-diff --git a/Network/Socket/Internal.hsc b/Network/Socket/Internal.hsc
-deleted file mode 100644
-index 1372b25..0000000
---- a/Network/Socket/Internal.hsc
-+++ /dev/null
-@@ -1,274 +0,0 @@
--{-# LANGUAGE CPP #-}
--{-# LANGUAGE ForeignFunctionInterface #-}
--{-# OPTIONS_GHC -fno-warn-orphans #-}
-------------------------------------------------------------------------------
---- |
---- Module      :  Network.Socket.Internal
---- Copyright   :  (c) The University of Glasgow 2001
---- License     :  BSD-style (see the file libraries/network/LICENSE)
----
---- Maintainer  :  libraries@haskell.org
---- Stability   :  provisional
---- Portability :  portable
----
---- A module containing semi-public 'Network.Socket' internals.
---- Modules which extend the 'Network.Socket' module will need to use
---- this module while ideally most users will be able to make do with
---- the public interface.
----
-------------------------------------------------------------------------------
--
--#include "HsNet.h"
--
--module Network.Socket.Internal
--    (
--    -- * Socket addresses
--      HostAddress
--#if defined(IPV6_SOCKET_SUPPORT)
--    , HostAddress6
--    , FlowInfo
--    , ScopeID
--#endif
--    , PortNumber(..)
--    , SockAddr(..)
--
+ 
+ -- ---------------------------------------------------------------------------
+ -- WinSock support
+diff --git a/Network/Socket/Types.hsc b/Network/Socket/Types.hs
+similarity index 73%
+rename from Network/Socket/Types.hsc
+rename to Network/Socket/Types.hs
+index bed07d1..4fc6f89 100644
+--- a/Network/Socket/Types.hsc
++++ b/Network/Socket/Types.hs
+@@ -33,6 +33,8 @@ module Network.Socket.Types
+     -- * Socket addresses
+     , SockAddr(..)
+     , isSupportedSockAddr
++    , newSockAddr
++    , withSockAddr
+     , HostAddress
+     , hostAddressToTuple
+     , tupleToHostAddress
+@@ -43,12 +45,16 @@ module Network.Socket.Types
+     , FlowInfo
+     , ScopeID
+ #endif
 -    , peekSockAddr
 -    , pokeSockAddr
 -    , sizeOfSockAddr
 -    , sizeOfSockAddrByFamily
 -    , withSockAddr
 -    , withNewSockAddr
--
--    -- * Protocol families
--    , Family(..)
--
--    -- * Socket error functions
--#if defined(HAVE_WINSOCK2_H)
--    , c_getLastError
--#endif
--    , throwSocketError
--    , throwSocketErrorCode
--
--    -- * Guards for socket operations that may fail
--    , throwSocketErrorIfMinus1_
--    , throwSocketErrorIfMinus1Retry
--    , throwSocketErrorIfMinus1Retry_
--    , throwSocketErrorIfMinus1RetryMayBlock
--
--    -- ** Guards that wait and retry if the operation would block
--    -- | These guards are based on 'throwSocketErrorIfMinus1RetryMayBlock'.
--    -- They wait for socket readiness if the action fails with @EWOULDBLOCK@
--    -- or similar.
--    , throwSocketErrorWaitRead
--    , throwSocketErrorWaitWrite
--
--    -- * Initialization
--    , withSocketsDo
--
--    -- * Low-level helpers
--    , zeroMemory
--    ) where
--
--import Foreign.C.Error (throwErrno, throwErrnoIfMinus1Retry,
--                        throwErrnoIfMinus1RetryMayBlock, throwErrnoIfMinus1_,
--                        Errno(..), errnoToIOError)
--#if defined(HAVE_WINSOCK2_H)
--import Foreign.C.String (peekCString)
--import Foreign.Ptr (Ptr)
--#endif
--import Foreign.C.Types (CInt(..))
--import GHC.Conc (threadWaitRead, threadWaitWrite)
--
--#if defined(HAVE_WINSOCK2_H)
--import Control.Exception ( evaluate )
--import System.IO.Unsafe ( unsafePerformIO )
--import Control.Monad ( when )
--#  if __GLASGOW_HASKELL__ >= 707
--import GHC.IO.Exception ( IOErrorType(..) )
--#  else
--import GHC.IOBase ( IOErrorType(..) )
--#  endif
--import Foreign.C.Types ( CChar )
--import System.IO.Error ( ioeSetErrorString, mkIOError )
--#endif
--
--import Network.Socket.Types
--
---- ---------------------------------------------------------------------
---- Guards for socket operations that may fail
--
---- | Throw an 'IOError' corresponding to the current socket error.
--throwSocketError :: String  -- ^ textual description of the error location
--                 -> IO a
--
---- | Like 'throwSocketError', but the error code is supplied as an argument.
----
---- On Windows, do not use errno.  Use a system error code instead.
--throwSocketErrorCode :: String -> CInt -> IO a
--
---- | Throw an 'IOError' corresponding to the current socket error if
---- the IO action returns a result of @-1@.  Discards the result of the
---- IO action after error handling.
--throwSocketErrorIfMinus1_
--    :: (Eq a, Num a)
--    => String  -- ^ textual description of the location
--    -> IO a    -- ^ the 'IO' operation to be executed
--    -> IO ()
--
--{-# SPECIALIZE throwSocketErrorIfMinus1_ :: String -> IO CInt -> IO () #-}
--
---- | Throw an 'IOError' corresponding to the current socket error if
---- the IO action returns a result of @-1@, but retries in case of an
---- interrupted operation.
--throwSocketErrorIfMinus1Retry
--    :: (Eq a, Num a)
--    => String  -- ^ textual description of the location
--    -> IO a    -- ^ the 'IO' operation to be executed
--    -> IO a
--
--{-# SPECIALIZE throwSocketErrorIfMinus1Retry :: String -> IO CInt -> IO CInt #-}
--
---- | Throw an 'IOError' corresponding to the current socket error if
---- the IO action returns a result of @-1@, but retries in case of an
---- interrupted operation. Discards the result of the IO action after
---- error handling.
--throwSocketErrorIfMinus1Retry_
--    :: (Eq a, Num a)
--    => String  -- ^ textual description of the location
--    -> IO a    -- ^ the 'IO' operation to be executed
--    -> IO ()
--throwSocketErrorIfMinus1Retry_ loc m =
--    throwSocketErrorIfMinus1Retry loc m >> return ()
--{-# SPECIALIZE throwSocketErrorIfMinus1Retry_ :: String -> IO CInt -> IO () #-}
--
---- | Throw an 'IOError' corresponding to the current socket error if
---- the IO action returns a result of @-1@, but retries in case of an
---- interrupted operation.  Checks for operations that would block and
---- executes an alternative action before retrying in that case.
--throwSocketErrorIfMinus1RetryMayBlock
--    :: (Eq a, Num a)
--    => String  -- ^ textual description of the location
--    -> IO b    -- ^ action to execute before retrying if an
--               --   immediate retry would block
--    -> IO a    -- ^ the 'IO' operation to be executed
--    -> IO a
--
--{-# SPECIALIZE throwSocketErrorIfMinus1RetryMayBlock
--        :: String -> IO b -> IO CInt -> IO CInt #-}
--
--#if (!defined(HAVE_WINSOCK2_H))
--
--throwSocketErrorIfMinus1RetryMayBlock name on_block act =
--    throwErrnoIfMinus1RetryMayBlock name act on_block
--
--throwSocketErrorIfMinus1Retry = throwErrnoIfMinus1Retry
--
--throwSocketErrorIfMinus1_ = throwErrnoIfMinus1_
--
--throwSocketError = throwErrno
--
--throwSocketErrorCode loc errno =
--    ioError (errnoToIOError loc (Errno errno) Nothing Nothing)
--
--#else
--
--throwSocketErrorIfMinus1RetryMayBlock name _ act
--  = throwSocketErrorIfMinus1Retry name act
--
--throwSocketErrorIfMinus1_ name act = do
--  throwSocketErrorIfMinus1Retry name act
--  return ()
--
--# if defined(HAVE_WINSOCK2_H)
--throwSocketErrorIfMinus1Retry name act = do
--  r <- act
--  if (r == -1)
--   then do
--    rc   <- c_getLastError
--    case rc of
--      #{const WSANOTINITIALISED} -> do
--        withSocketsDo (return ())
--        r <- act
--        if (r == -1)
--           then throwSocketError name
--           else return r
--      _ -> throwSocketError name
--   else return r
--
--throwSocketErrorCode name rc = do
--    pstr <- c_getWSError rc
--    str  <- peekCString pstr
--    ioError (ioeSetErrorString (mkIOError OtherError name Nothing Nothing) str)
--
--throwSocketError name =
--    c_getLastError >>= throwSocketErrorCode name
--
--foreign import CALLCONV unsafe "WSAGetLastError"
--  c_getLastError :: IO CInt
--
--foreign import ccall unsafe "getWSErrorDescr"
--  c_getWSError :: CInt -> IO (Ptr CChar)
--
--
--# else
--throwSocketErrorIfMinus1Retry = throwErrnoIfMinus1Retry
--throwSocketError = throwErrno
--throwSocketErrorCode loc errno =
--    ioError (errnoToIOError loc (Errno errno) Nothing Nothing)
--# endif
--#endif
--
---- | Like 'throwSocketErrorIfMinus1Retry', but if the action fails with
---- @EWOULDBLOCK@ or similar, wait for the socket to be read-ready,
---- and try again.
--throwSocketErrorWaitRead :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
--throwSocketErrorWaitRead sock name io =
--    throwSocketErrorIfMinus1RetryMayBlock name
--        (threadWaitRead $ fromIntegral $ sockFd sock)
--        io
--
---- | Like 'throwSocketErrorIfMinus1Retry', but if the action fails with
---- @EWOULDBLOCK@ or similar, wait for the socket to be write-ready,
---- and try again.
--throwSocketErrorWaitWrite :: (Eq a, Num a) => Socket -> String -> IO a -> IO a
--throwSocketErrorWaitWrite sock name io =
--    throwSocketErrorIfMinus1RetryMayBlock name
--        (threadWaitWrite $ fromIntegral $ sockFd sock)
--        io
--
---- ---------------------------------------------------------------------------
---- WinSock support
--
--{-| With older versions of the @network@ library on Windows operating systems,
--the networking subsystem must be initialised using 'withSocketsDo' before
--any networking operations can be used. eg.
--
--> main = withSocketsDo $ do {...}
--
--It is fine to nest calls to 'withSocketsDo', and to perform networking operations
--after 'withSocketsDo' has returned.
--
--In newer versions of the @network@ library it is only necessary to call
--'withSocketsDo' if you are calling the 'MkSocket' constructor directly.
--However, for compatibility with older versions on Windows, it is good practice
--to always call 'withSocketsDo' (it's very cheap).
---}
--{-# INLINE withSocketsDo #-}
--withSocketsDo :: IO a -> IO a
--#if !defined(WITH_WINSOCK)
--withSocketsDo x = x
--#else
--withSocketsDo act = evaluate withSocketsInit >> act
--
--
--{-# NOINLINE withSocketsInit #-}
--withSocketsInit :: ()
---- Use a CAF to make forcing it do initialisation once, but subsequent forces will be cheap
--withSocketsInit = unsafePerformIO $ do
--    x <- initWinSock
--    when (x /= 0) $ ioError $
--      userError "Network.Socket.Internal.withSocketsDo: Failed to initialise WinSock"
--
--foreign import ccall unsafe "initWinSock" initWinSock :: IO Int
--
--#endif
-diff --git a/Network/Socket/Types.hs b/Network/Socket/Types.hs
-new file mode 100644
-index 0000000..4fc6f89
---- /dev/null
-+++ b/Network/Socket/Types.hs
-@@ -0,0 +1,1001 @@
-+{-# LANGUAGE DeriveDataTypeable #-}
-+{-# LANGUAGE FlexibleInstances #-}
-+{-# LANGUAGE ForeignFunctionInterface #-}
-+
-+#include "HsNet.h"
-+
-+module Network.Socket.Types
-+    (
-+    -- * Socket
-+      Socket(..)
-+    , sockFd
-+    , sockFamily
-+    , sockType
-+    , sockProtocol
-+    , sockStatus
-+    , SocketStatus(..)
-+
-+    -- * Socket types
-+    , SocketType(..)
-+    , isSupportedSocketType
-+    , packSocketType
-+    , packSocketType'
-+    , packSocketTypeOrThrow
-+    , unpackSocketType
-+    , unpackSocketType'
-+
-+    -- * Family
-+    , Family(..)
-+    , isSupportedFamily
-+    , packFamily
-+    , unpackFamily
-+
-+    -- * Socket addresses
-+    , SockAddr(..)
-+    , isSupportedSockAddr
-+    , newSockAddr
-+    , withSockAddr
-+    , HostAddress
-+    , hostAddressToTuple
-+    , tupleToHostAddress
-+#if defined(IPV6_SOCKET_SUPPORT)
-+    , HostAddress6
-+    , hostAddress6ToTuple
-+    , tupleToHostAddress6
-+    , FlowInfo
-+    , ScopeID
-+#endif
 +    , SocketAddress
 +    , InetSocketAddress
 +    , InetAddress
@@ -5628,1129 +1754,80 @@ index 0000000..4fc6f89
 +    , mkInetSocketAddress
 +    , inetAddrInt
 +    , toJByteArray
-+
-+    -- * Unsorted
-+    , ProtocolNumber
-+    , PortNumber(..)
-+
-+    -- * Low-level helpers
-+    , zeroMemory
-+    ) where
-+
-+import Control.Concurrent.MVar
-+import Control.Monad
-+import Data.Bits
-+import Data.Maybe
-+import Data.Ratio
-+import Data.Typeable
-+import Data.Word
-+import Data.Int
-+import Foreign.C
-+import Foreign.Ptr
-+import Foreign.Storable
+ 
+     -- * Unsorted
+     , ProtocolNumber
+@@ -67,10 +73,11 @@ import Data.Typeable
+ import Data.Word
+ import Data.Int
+ import Foreign.C
+-import Foreign.Marshal.Alloc
+-import Foreign.Marshal.Array
+ import Foreign.Ptr
+ import Foreign.Storable
 +import System.Posix.Types (Channel)
 +
 +import Java
-+
-+-- | Represents a socket.  The fields are, respectively:
-+--
-+--   * File descriptor
-+--   * Socket family
-+--   * Socket type
-+--   * Protocol number
-+--   * Status flag
-+--
-+--   If you are calling the 'MkSocket' constructor directly you should ensure
-+--   you have called 'Network.withSocketsDo' and that the file descriptor is
-+--   in non-blocking mode. See 'Network.Socket.setNonBlockIfNeeded'.
-+data Socket
-+  = MkSocket
+ 
+ -- | Represents a socket.  The fields are, respectively:
+ --
+@@ -85,14 +92,14 @@ import Foreign.Storable
+ --   in non-blocking mode. See 'Network.Socket.setNonBlockIfNeeded'.
+ data Socket
+   = MkSocket
+-            CInt                 -- File Descriptor
 +            Channel              -- File Descriptor
-+            Family
-+            SocketType
-+            ProtocolNumber       -- Protocol Number
-+            (MVar SocketStatus)  -- Status Flag
-+  deriving Typeable
-+
+             Family
+             SocketType
+             ProtocolNumber       -- Protocol Number
+             (MVar SocketStatus)  -- Status Flag
+   deriving Typeable
+ 
+-sockFd :: Socket -> CInt
 +sockFd :: Socket -> Channel
-+sockFd       (MkSocket n _ _ _ _) = n
-+
-+sockFamily :: Socket -> Family
-+sockFamily   (MkSocket _ f _ _ _) = f
-+
-+sockType :: Socket -> SocketType
-+sockType     (MkSocket _ _ t _ _) = t
-+
-+sockProtocol :: Socket -> ProtocolNumber
-+sockProtocol (MkSocket _ _ _ p _) = p
-+
-+sockStatus :: Socket -> MVar SocketStatus
-+sockStatus   (MkSocket _ _ _ _ s) = s
-+
-+instance Eq Socket where
-+  (MkSocket _ _ _ _ m1) == (MkSocket _ _ _ _ m2) = m1 == m2
-+
-+instance Show Socket where
-+  showsPrec _n (MkSocket fd _ _ _ _) =
+ sockFd       (MkSocket n _ _ _ _) = n
+ 
+ sockFamily :: Socket -> Family
+@@ -112,7 +119,12 @@ instance Eq Socket where
+ 
+ instance Show Socket where
+   showsPrec _n (MkSocket fd _ _ _ _) =
 +#if ((ETA_VERSION == 9) && (ETA_BUILD_NUMBER >= 2)) || (ETA_VERSION > 9)
-+        showString "<socket: " . shows fd . showString ">"
+         showString "<socket: " . shows fd . showString ">"
 +#else
 +        showString "<socket" . showString ">"
 +#endif
 +
-+
-+type ProtocolNumber = CInt
-+
-+-- | The status of the socket as /determined by this library/, not
-+-- necessarily reflecting the state of the connection itself.
-+--
-+-- For example, the 'Closed' status is applied when the 'close'
-+-- function is called.
-+data SocketStatus
-+  -- Returned Status    Function called
-+  = NotConnected        -- ^ Newly created, unconnected socket
-+  | Bound SockAddr      -- ^ Bound, via 'bind'
-+  | Listening           -- ^ Listening, via 'listen'
-+  | Connected           -- ^ Connected or accepted, via 'connect' or 'accept'
-+  | ConvertedToHandle   -- ^ Is now a 'Handle' (via 'socketToHandle'), don't touch
-+  | Closed              -- ^ Closed was closed by 'close'
-+    deriving (Eq, Typeable)
-+
-+-----------------------------------------------------------------------------
-+-- Socket types
-+
-+-- There are a few possible ways to do this.  The first is convert the
-+-- structs used in the C library into an equivalent Haskell type. An
-+-- other possible implementation is to keep all the internals in the C
-+-- code and use an Int## and a status flag. The second method is used
-+-- here since a lot of the C structures are not required to be
-+-- manipulated.
-+
-+-- Originally the status was non-mutable so we had to return a new
-+-- socket each time we changed the status.  This version now uses
-+-- mutable variables to avoid the need to do this.  The result is a
-+-- cleaner interface and better security since the application
-+-- programmer now can't circumvent the status information to perform
-+-- invalid operations on sockets.
-+
-+-- | Socket Types.
-+--
-+-- The existence of a constructor does not necessarily imply that that
-+-- socket type is supported on your system: see 'isSupportedSocketType'.
-+data SocketType
-+        = NoSocketType -- ^ 0, used in getAddrInfo hints, for example
-+        | Stream -- ^ SOCK_STREAM
-+        | Datagram -- ^ SOCK_DGRAM
-+        | Raw -- ^ SOCK_RAW
-+        | RDM -- ^ SOCK_RDM
-+        | SeqPacket -- ^ SOCK_SEQPACKET
-+        | ServerSocket SocketType -- ^ ServerSocket
-+        deriving (Eq, Ord, Read, Show, Typeable)
-+
-+-- | Does the SOCK_ constant corresponding to the given SocketType exist on
-+-- this system?
-+isSupportedSocketType :: SocketType -> Bool
-+isSupportedSocketType = isJust . packSocketType'
-+
-+-- | Find the SOCK_ constant corresponding to the SocketType value.
-+packSocketType' :: SocketType -> Maybe CInt
-+packSocketType' stype = case Just stype of
-+    -- the Just above is to disable GHC's overlapping pattern
-+    -- detection: see comments for packSocketOption
-+    Just NoSocketType     -> Just 0
-+    Just Stream           -> Just 1
-+    Just Datagram         -> Just 2
-+    Just (ServerSocket _) -> Just 3
-+    _                     -> Nothing
-+
-+packSocketType :: SocketType -> CInt
-+packSocketType stype = fromMaybe (error errMsg) (packSocketType' stype)
-+  where
-+    errMsg = concat ["Network.Socket.packSocketType: ",
-+                     "socket type ", show stype, " unsupported on this system"]
-+
-+-- | Try packSocketType' on the SocketType, if it fails throw an error with
-+-- message starting "Network.Socket." ++ the String parameter
-+packSocketTypeOrThrow :: String -> SocketType -> IO CInt
-+packSocketTypeOrThrow caller stype = maybe err return (packSocketType' stype)
-+ where
-+  err = ioError . userError . concat $ ["Network.Socket.", caller, ": ",
-+    "socket type ", show stype, " unsupported on this system"]
-+
-+
-+unpackSocketType:: CInt -> Maybe SocketType
-+unpackSocketType t = case t of
-+        0 -> Just NoSocketType
-+#ifdef SOCK_STREAM
-+        1 -> Just Stream
-+#endif
-+#ifdef SOCK_DGRAM
-+        2 -> Just Datagram
-+#endif
-+#ifdef SOCK_STREAM
-+        3 -> Just (ServerSocket Stream)
-+#endif
-+#ifdef SOCK_RAW
-+        (#const SOCK_RAW) -> Just Raw
-+#endif
-+#ifdef SOCK_RDM
-+        (#const SOCK_RDM) -> Just RDM
-+#endif
-+#ifdef SOCK_SEQPACKET
-+        (#const SOCK_SEQPACKET) -> Just SeqPacket
-+#endif
-+        _ -> Nothing
-+
-+-- | Try unpackSocketType on the CInt, if it fails throw an error with
-+-- message starting "Network.Socket." ++ the String parameter
-+unpackSocketType' :: String -> CInt -> IO SocketType
-+unpackSocketType' caller ty = maybe err return (unpackSocketType ty)
-+ where
-+  err = ioError . userError . concat $ ["Network.Socket.", caller, ": ",
-+    "socket type ", show ty, " unsupported on this system"]
-+
-+------------------------------------------------------------------------
-+-- Protocol Families.
-+
-+-- | Address families.
-+--
-+-- A constructor being present here does not mean it is supported by the
-+-- operating system: see 'isSupportedFamily'.
-+data Family
-+    = AF_UNSPEC           -- unspecified
-+    | AF_UNIX             -- local to host (pipes, portals
-+    | AF_INET             -- internetwork: UDP, TCP, etc
-+    | AF_INET6            -- Internet Protocol version 6
-+    | AF_IMPLINK          -- arpanet imp addresses
-+    | AF_PUP              -- pup protocols: e.g. BSP
-+    | AF_CHAOS            -- mit CHAOS protocols
-+    | AF_NS               -- XEROX NS protocols
-+    | AF_NBS              -- nbs protocols
-+    | AF_ECMA             -- european computer manufacturers
-+    | AF_DATAKIT          -- datakit protocols
-+    | AF_CCITT            -- CCITT protocols, X.25 etc
-+    | AF_SNA              -- IBM SNA
-+    | AF_DECnet           -- DECnet
-+    | AF_DLI              -- Direct data link interface
-+    | AF_LAT              -- LAT
-+    | AF_HYLINK           -- NSC Hyperchannel
-+    | AF_APPLETALK        -- Apple Talk
-+    | AF_ROUTE            -- Internal Routing Protocol
-+    | AF_NETBIOS          -- NetBios-style addresses
-+    | AF_NIT              -- Network Interface Tap
-+    | AF_802              -- IEEE 802.2, also ISO 8802
-+    | AF_ISO              -- ISO protocols
-+    | AF_OSI              -- umbrella of all families used by OSI
-+    | AF_NETMAN           -- DNA Network Management
-+    | AF_X25              -- CCITT X.25
-+    | AF_AX25
-+    | AF_OSINET           -- AFI
-+    | AF_GOSSIP           -- US Government OSI
-+    | AF_IPX              -- Novell Internet Protocol
-+    | Pseudo_AF_XTP       -- eXpress Transfer Protocol (no AF)
-+    | AF_CTF              -- Common Trace Facility
-+    | AF_WAN              -- Wide Area Network protocols
-+    | AF_SDL              -- SGI Data Link for DLPI
-+    | AF_NETWARE
-+    | AF_NDD
-+    | AF_INTF             -- Debugging use only
-+    | AF_COIP             -- connection-oriented IP, aka ST II
-+    | AF_CNT              -- Computer Network Technology
-+    | Pseudo_AF_RTIP      -- Help Identify RTIP packets
-+    | Pseudo_AF_PIP       -- Help Identify PIP packets
-+    | AF_SIP              -- Simple Internet Protocol
-+    | AF_ISDN             -- Integrated Services Digital Network
-+    | Pseudo_AF_KEY       -- Internal key-management function
-+    | AF_NATM             -- native ATM access
-+    | AF_ARP              -- (rev.) addr. res. prot. (RFC 826)
-+    | Pseudo_AF_HDRCMPLT  -- Used by BPF to not rewrite hdrs in iface output
-+    | AF_ENCAP
-+    | AF_LINK             -- Link layer interface
-+    | AF_RAW              -- Link layer interface
-+    | AF_RIF              -- raw interface
-+    | AF_NETROM           -- Amateur radio NetROM
-+    | AF_BRIDGE           -- multiprotocol bridge
-+    | AF_ATMPVC           -- ATM PVCs
-+    | AF_ROSE             -- Amateur Radio X.25 PLP
-+    | AF_NETBEUI          -- 802.2LLC
-+    | AF_SECURITY         -- Security callback pseudo AF
-+    | AF_PACKET           -- Packet family
-+    | AF_ASH              -- Ash
-+    | AF_ECONET           -- Acorn Econet
-+    | AF_ATMSVC           -- ATM SVCs
-+    | AF_IRDA             -- IRDA sockets
-+    | AF_PPPOX            -- PPPoX sockets
-+    | AF_WANPIPE          -- Wanpipe API sockets
-+    | AF_BLUETOOTH        -- bluetooth sockets
-+    | AF_CAN              -- Controller Area Network
-+      deriving (Eq, Ord, Read, Show)
-+
-+packFamily :: Family -> CInt
-+packFamily f = case packFamily' f of
-+    Just fam -> fam
-+    Nothing -> error $
-+               "Network.Socket.packFamily: unsupported address family: " ++
-+               show f
-+
-+-- | Does the AF_ constant corresponding to the given family exist on this
-+-- system?
-+isSupportedFamily :: Family -> Bool
-+isSupportedFamily = isJust . packFamily'
-+
-+packFamily' :: Family -> Maybe CInt
-+packFamily' f = case Just f of
-+    -- the Just above is to disable GHC's overlapping pattern
-+    -- detection: see comments for packSocketOption
-+    Just AF_UNSPEC -> Just 0
-+#ifdef AF_UNIX
-+    Just AF_UNIX -> Just #const AF_UNIX
-+#endif
-+#ifdef DEF_AF_INET
-+    Just AF_INET -> Just 1
-+#endif
-+#ifdef DEF_AF_INET6
-+    Just AF_INET6 -> Just 2
-+#endif
-+#ifdef AF_IMPLINK
-+    Just AF_IMPLINK -> Just #const AF_IMPLINK
-+#endif
-+#ifdef AF_PUP
-+    Just AF_PUP -> Just #const AF_PUP
-+#endif
-+#ifdef AF_CHAOS
-+    Just AF_CHAOS -> Just #const AF_CHAOS
-+#endif
-+#ifdef AF_NS
-+    Just AF_NS -> Just #const AF_NS
-+#endif
-+#ifdef AF_NBS
-+    Just AF_NBS -> Just #const AF_NBS
-+#endif
-+#ifdef AF_ECMA
-+    Just AF_ECMA -> Just #const AF_ECMA
-+#endif
-+#ifdef AF_DATAKIT
-+    Just AF_DATAKIT -> Just #const AF_DATAKIT
-+#endif
-+#ifdef AF_CCITT
-+    Just AF_CCITT -> Just #const AF_CCITT
-+#endif
-+#ifdef AF_SNA
-+    Just AF_SNA -> Just #const AF_SNA
-+#endif
-+#ifdef AF_DECnet
-+    Just AF_DECnet -> Just #const AF_DECnet
-+#endif
-+#ifdef AF_DLI
-+    Just AF_DLI -> Just #const AF_DLI
-+#endif
-+#ifdef AF_LAT
-+    Just AF_LAT -> Just #const AF_LAT
-+#endif
-+#ifdef AF_HYLINK
-+    Just AF_HYLINK -> Just #const AF_HYLINK
-+#endif
-+#ifdef AF_APPLETALK
-+    Just AF_APPLETALK -> Just #const AF_APPLETALK
-+#endif
-+#ifdef AF_ROUTE
-+    Just AF_ROUTE -> Just #const AF_ROUTE
-+#endif
-+#ifdef AF_NETBIOS
-+    Just AF_NETBIOS -> Just #const AF_NETBIOS
-+#endif
-+#ifdef AF_NIT
-+    Just AF_NIT -> Just #const AF_NIT
-+#endif
-+#ifdef AF_802
-+    Just AF_802 -> Just #const AF_802
-+#endif
-+#ifdef AF_ISO
-+    Just AF_ISO -> Just #const AF_ISO
-+#endif
-+#ifdef AF_OSI
-+    Just AF_OSI -> Just #const AF_OSI
-+#endif
-+#ifdef AF_NETMAN
-+    Just AF_NETMAN -> Just #const AF_NETMAN
-+#endif
-+#ifdef AF_X25
-+    Just AF_X25 -> Just #const AF_X25
-+#endif
-+#ifdef AF_AX25
-+    Just AF_AX25 -> Just #const AF_AX25
-+#endif
-+#ifdef AF_OSINET
-+    Just AF_OSINET -> Just #const AF_OSINET
-+#endif
-+#ifdef AF_GOSSIP
-+    Just AF_GOSSIP -> Just #const AF_GOSSIP
-+#endif
-+#ifdef AF_IPX
-+    Just AF_IPX -> Just #const AF_IPX
-+#endif
-+#ifdef Pseudo_AF_XTP
-+    Just Pseudo_AF_XTP -> Just #const Pseudo_AF_XTP
-+#endif
-+#ifdef AF_CTF
-+    Just AF_CTF -> Just #const AF_CTF
-+#endif
-+#ifdef AF_WAN
-+    Just AF_WAN -> Just #const AF_WAN
-+#endif
-+#ifdef AF_SDL
-+    Just AF_SDL -> Just #const AF_SDL
-+#endif
-+#ifdef AF_NETWARE
-+    Just AF_NETWARE -> Just #const AF_NETWARE
-+#endif
-+#ifdef AF_NDD
-+    Just AF_NDD -> Just #const AF_NDD
-+#endif
-+#ifdef AF_INTF
-+    Just AF_INTF -> Just #const AF_INTF
-+#endif
-+#ifdef AF_COIP
-+    Just AF_COIP -> Just #const AF_COIP
-+#endif
-+#ifdef AF_CNT
-+    Just AF_CNT -> Just #const AF_CNT
-+#endif
-+#ifdef Pseudo_AF_RTIP
-+    Just Pseudo_AF_RTIP -> Just #const Pseudo_AF_RTIP
-+#endif
-+#ifdef Pseudo_AF_PIP
-+    Just Pseudo_AF_PIP -> Just #const Pseudo_AF_PIP
-+#endif
-+#ifdef AF_SIP
-+    Just AF_SIP -> Just #const AF_SIP
-+#endif
-+#ifdef AF_ISDN
-+    Just AF_ISDN -> Just #const AF_ISDN
-+#endif
-+#ifdef Pseudo_AF_KEY
-+    Just Pseudo_AF_KEY -> Just #const Pseudo_AF_KEY
-+#endif
-+#ifdef AF_NATM
-+    Just AF_NATM -> Just #const AF_NATM
-+#endif
-+#ifdef AF_ARP
-+    Just AF_ARP -> Just #const AF_ARP
-+#endif
-+#ifdef Pseudo_AF_HDRCMPLT
-+    Just Pseudo_AF_HDRCMPLT -> Just #const Pseudo_AF_HDRCMPLT
-+#endif
-+#ifdef AF_ENCAP
-+    Just AF_ENCAP -> Just #const AF_ENCAP
-+#endif
-+#ifdef AF_LINK
-+    Just AF_LINK -> Just #const AF_LINK
-+#endif
-+#ifdef AF_RAW
-+    Just AF_RAW -> Just #const AF_RAW
-+#endif
-+#ifdef AF_RIF
-+    Just AF_RIF -> Just #const AF_RIF
-+#endif
-+#ifdef AF_NETROM
-+    Just AF_NETROM -> Just #const AF_NETROM
-+#endif
-+#ifdef AF_BRIDGE
-+    Just AF_BRIDGE -> Just #const AF_BRIDGE
-+#endif
-+#ifdef AF_ATMPVC
-+    Just AF_ATMPVC -> Just #const AF_ATMPVC
-+#endif
-+#ifdef AF_ROSE
-+    Just AF_ROSE -> Just #const AF_ROSE
-+#endif
-+#ifdef AF_NETBEUI
-+    Just AF_NETBEUI -> Just #const AF_NETBEUI
-+#endif
-+#ifdef AF_SECURITY
-+    Just AF_SECURITY -> Just #const AF_SECURITY
-+#endif
-+#ifdef AF_PACKET
-+    Just AF_PACKET -> Just #const AF_PACKET
-+#endif
-+#ifdef AF_ASH
-+    Just AF_ASH -> Just #const AF_ASH
-+#endif
-+#ifdef AF_ECONET
-+    Just AF_ECONET -> Just #const AF_ECONET
-+#endif
-+#ifdef AF_ATMSVC
-+    Just AF_ATMSVC -> Just #const AF_ATMSVC
-+#endif
-+#ifdef AF_IRDA
-+    Just AF_IRDA -> Just #const AF_IRDA
-+#endif
-+#ifdef AF_PPPOX
-+    Just AF_PPPOX -> Just #const AF_PPPOX
-+#endif
-+#ifdef AF_WANPIPE
-+    Just AF_WANPIPE -> Just #const AF_WANPIPE
-+#endif
-+#ifdef AF_BLUETOOTH
-+    Just AF_BLUETOOTH -> Just #const AF_BLUETOOTH
-+#endif
-+#ifdef AF_CAN
-+    Just AF_CAN -> Just #const AF_CAN
-+#endif
-+    _ -> Nothing
-+
-+--------- ----------
-+
-+unpackFamily :: CInt -> Family
-+unpackFamily f = case f of
-+        0 -> AF_UNSPEC
-+#ifdef AF_UNIX
-+        (#const AF_UNIX) -> AF_UNIX
-+#endif
-+#ifdef DEF_AF_INET
-+        1 -> AF_INET
-+#endif
-+#ifdef DEF_AF_INET6
-+        2 -> AF_INET6
-+#endif
-+#ifdef AF_IMPLINK
-+        (#const AF_IMPLINK) -> AF_IMPLINK
-+#endif
-+#ifdef AF_PUP
-+        (#const AF_PUP) -> AF_PUP
-+#endif
-+#ifdef AF_CHAOS
-+        (#const AF_CHAOS) -> AF_CHAOS
-+#endif
-+#ifdef AF_NS
-+        (#const AF_NS) -> AF_NS
-+#endif
-+#ifdef AF_NBS
-+        (#const AF_NBS) -> AF_NBS
-+#endif
-+#ifdef AF_ECMA
-+        (#const AF_ECMA) -> AF_ECMA
-+#endif
-+#ifdef AF_DATAKIT
-+        (#const AF_DATAKIT) -> AF_DATAKIT
-+#endif
-+#ifdef AF_CCITT
-+        (#const AF_CCITT) -> AF_CCITT
-+#endif
-+#ifdef AF_SNA
-+        (#const AF_SNA) -> AF_SNA
-+#endif
-+#ifdef AF_DECnet
-+        (#const AF_DECnet) -> AF_DECnet
-+#endif
-+#ifdef AF_DLI
-+        (#const AF_DLI) -> AF_DLI
-+#endif
-+#ifdef AF_LAT
-+        (#const AF_LAT) -> AF_LAT
-+#endif
-+#ifdef AF_HYLINK
-+        (#const AF_HYLINK) -> AF_HYLINK
-+#endif
-+#ifdef AF_APPLETALK
-+        (#const AF_APPLETALK) -> AF_APPLETALK
-+#endif
-+#ifdef AF_ROUTE
-+        (#const AF_ROUTE) -> AF_ROUTE
-+#endif
-+#ifdef AF_NETBIOS
-+        (#const AF_NETBIOS) -> AF_NETBIOS
-+#endif
-+#ifdef AF_NIT
-+        (#const AF_NIT) -> AF_NIT
-+#endif
-+#ifdef AF_802
-+        (#const AF_802) -> AF_802
-+#endif
-+#ifdef AF_ISO
-+        (#const AF_ISO) -> AF_ISO
-+#endif
-+#ifdef AF_OSI
-+# if (!defined(AF_ISO)) || (defined(AF_ISO) && (AF_ISO != AF_OSI))
-+        (#const AF_OSI) -> AF_OSI
-+# endif
-+#endif
-+#ifdef AF_NETMAN
-+        (#const AF_NETMAN) -> AF_NETMAN
-+#endif
-+#ifdef AF_X25
-+        (#const AF_X25) -> AF_X25
-+#endif
-+#ifdef AF_AX25
-+        (#const AF_AX25) -> AF_AX25
-+#endif
-+#ifdef AF_OSINET
-+        (#const AF_OSINET) -> AF_OSINET
-+#endif
-+#ifdef AF_GOSSIP
-+        (#const AF_GOSSIP) -> AF_GOSSIP
-+#endif
-+#if defined(AF_IPX) && (!defined(AF_NS) || AF_NS != AF_IPX)
-+        (#const AF_IPX) -> AF_IPX
-+#endif
-+#ifdef Pseudo_AF_XTP
-+        (#const Pseudo_AF_XTP) -> Pseudo_AF_XTP
-+#endif
-+#ifdef AF_CTF
-+        (#const AF_CTF) -> AF_CTF
-+#endif
-+#ifdef AF_WAN
-+        (#const AF_WAN) -> AF_WAN
-+#endif
-+#ifdef AF_SDL
-+        (#const AF_SDL) -> AF_SDL
-+#endif
-+#ifdef AF_NETWARE
-+        (#const AF_NETWARE) -> AF_NETWARE
-+#endif
-+#ifdef AF_NDD
-+        (#const AF_NDD) -> AF_NDD
-+#endif
-+#ifdef AF_INTF
-+        (#const AF_INTF) -> AF_INTF
-+#endif
-+#ifdef AF_COIP
-+        (#const AF_COIP) -> AF_COIP
-+#endif
-+#ifdef AF_CNT
-+        (#const AF_CNT) -> AF_CNT
-+#endif
-+#ifdef Pseudo_AF_RTIP
-+        (#const Pseudo_AF_RTIP) -> Pseudo_AF_RTIP
-+#endif
-+#ifdef Pseudo_AF_PIP
-+        (#const Pseudo_AF_PIP) -> Pseudo_AF_PIP
-+#endif
-+#ifdef AF_SIP
-+        (#const AF_SIP) -> AF_SIP
-+#endif
-+#ifdef AF_ISDN
-+        (#const AF_ISDN) -> AF_ISDN
-+#endif
-+#ifdef Pseudo_AF_KEY
-+        (#const Pseudo_AF_KEY) -> Pseudo_AF_KEY
-+#endif
-+#ifdef AF_NATM
-+        (#const AF_NATM) -> AF_NATM
-+#endif
-+#ifdef AF_ARP
-+        (#const AF_ARP) -> AF_ARP
-+#endif
-+#ifdef Pseudo_AF_HDRCMPLT
-+        (#const Pseudo_AF_HDRCMPLT) -> Pseudo_AF_HDRCMPLT
-+#endif
-+#ifdef AF_ENCAP
-+        (#const AF_ENCAP) -> AF_ENCAP
-+#endif
-+#ifdef AF_LINK
-+        (#const AF_LINK) -> AF_LINK
-+#endif
-+#ifdef AF_RAW
-+        (#const AF_RAW) -> AF_RAW
-+#endif
-+#ifdef AF_RIF
-+        (#const AF_RIF) -> AF_RIF
-+#endif
-+#ifdef AF_NETROM
-+        (#const AF_NETROM) -> AF_NETROM
-+#endif
-+#ifdef AF_BRIDGE
-+        (#const AF_BRIDGE) -> AF_BRIDGE
-+#endif
-+#ifdef AF_ATMPVC
-+        (#const AF_ATMPVC) -> AF_ATMPVC
-+#endif
-+#ifdef AF_ROSE
-+        (#const AF_ROSE) -> AF_ROSE
-+#endif
-+#ifdef AF_NETBEUI
-+        (#const AF_NETBEUI) -> AF_NETBEUI
-+#endif
-+#ifdef AF_SECURITY
-+        (#const AF_SECURITY) -> AF_SECURITY
-+#endif
-+#ifdef AF_PACKET
-+        (#const AF_PACKET) -> AF_PACKET
-+#endif
-+#ifdef AF_ASH
-+        (#const AF_ASH) -> AF_ASH
-+#endif
-+#ifdef AF_ECONET
-+        (#const AF_ECONET) -> AF_ECONET
-+#endif
-+#ifdef AF_ATMSVC
-+        (#const AF_ATMSVC) -> AF_ATMSVC
-+#endif
-+#ifdef AF_IRDA
-+        (#const AF_IRDA) -> AF_IRDA
-+#endif
-+#ifdef AF_PPPOX
-+        (#const AF_PPPOX) -> AF_PPPOX
-+#endif
-+#ifdef AF_WANPIPE
-+        (#const AF_WANPIPE) -> AF_WANPIPE
-+#endif
-+#ifdef AF_BLUETOOTH
-+        (#const AF_BLUETOOTH) -> AF_BLUETOOTH
-+#endif
-+#ifdef AF_CAN
-+        (#const AF_CAN) -> AF_CAN
-+#endif
-+        unknown -> error $
-+          "Network.Socket.Types.unpackFamily: unknown address family: " ++
-+          show unknown
-+
-+------------------------------------------------------------------------
-+-- Port Numbers
-+
-+-- | Use the @Num@ instance (i.e. use a literal) to create a
-+-- @PortNumber@ value with the correct network-byte-ordering. You
-+-- should not use the PortNum constructor. It will be removed in the
-+-- next release.
-+--
-+-- >>> 1 :: PortNumber
-+-- 1
-+-- >>> read "1" :: PortNumber
-+-- 1
-+newtype PortNumber = PortNum Word16 deriving (Eq, Ord, Typeable)
-+-- newtyped to prevent accidental use of sane-looking
-+-- port numbers that haven't actually been converted to
-+-- network-byte-order first.
-+
-+{-# DEPRECATED PortNum "Do not use the PortNum constructor. Use the Num instance. PortNum will be removed in the next release." #-}
-+
-+instance Show PortNumber where
-+  showsPrec p pn = showsPrec p (portNumberToInt pn)
-+
-+instance Read PortNumber where
-+  readsPrec n = map (\(x,y) -> (intToPortNumber x, y)) . readsPrec n
-+
-+intToPortNumber :: Int -> PortNumber
-+intToPortNumber v = PortNum (fromIntegral v)
-+
-+portNumberToInt :: PortNumber -> Int
-+portNumberToInt (PortNum po) = fromIntegral po
-+
-+instance Enum PortNumber where
-+    toEnum   = intToPortNumber
-+    fromEnum = portNumberToInt
-+
-+instance Num PortNumber where
-+   fromInteger i = intToPortNumber (fromInteger i)
-+    -- for completeness.
-+   (+) x y   = intToPortNumber (portNumberToInt x + portNumberToInt y)
-+   (-) x y   = intToPortNumber (portNumberToInt x - portNumberToInt y)
-+   negate x  = intToPortNumber (-portNumberToInt x)
-+   (*) x y   = intToPortNumber (portNumberToInt x * portNumberToInt y)
-+   abs n     = intToPortNumber (abs (portNumberToInt n))
-+   signum n  = intToPortNumber (signum (portNumberToInt n))
-+
-+instance Real PortNumber where
-+    toRational x = toInteger x % 1
-+
-+instance Integral PortNumber where
-+    quotRem a b = let (c,d) = quotRem (portNumberToInt a) (portNumberToInt b) in
-+                  (intToPortNumber c, intToPortNumber d)
-+    toInteger a = toInteger (portNumberToInt a)
-+
-+instance Storable PortNumber where
-+   sizeOf    _ = sizeOf    (undefined :: Word16)
-+   alignment _ = alignment (undefined :: Word16)
-+   poke p (PortNum po) = poke (castPtr p) po
-+   peek p = PortNum `liftM` peek (castPtr p)
-+
-+------------------------------------------------------------------------
-+-- Socket addresses
-+
-+-- The scheme used for addressing sockets is somewhat quirky. The
-+-- calls in the BSD socket API that need to know the socket address
-+-- all operate in terms of struct sockaddr, a `virtual' type of
-+-- socket address.
-+
-+-- The Internet family of sockets are addressed as struct sockaddr_in,
-+-- so when calling functions that operate on struct sockaddr, we have
-+-- to type cast the Internet socket address into a struct sockaddr.
-+-- Instances of the structure for different families might *not* be
-+-- the same size. Same casting is required of other families of
-+-- sockets such as Xerox NS. Similarly for Unix domain sockets.
-+
-+-- To represent these socket addresses in Haskell-land, we do what BSD
-+-- didn't do, and use a union/algebraic type for the different
-+-- families. Currently only Unix domain sockets and the Internet
-+-- families are supported.
-+
-+#if defined(IPV6_SOCKET_SUPPORT)
-+type FlowInfo = Word32
-+type ScopeID = Word32
-+#endif
-+
-+-- | The existence of a constructor does not necessarily imply that
-+-- that socket address type is supported on your system: see
-+-- 'isSupportedSockAddr'.
-+data SockAddr       -- C Names
-+  = SockAddrInet
-+    PortNumber  -- sin_port  (network byte order)
-+    HostAddress -- sin_addr  (ditto)
-+  | SockAddrInet6
-+        PortNumber      -- sin6_port (network byte order)
-+        FlowInfo        -- sin6_flowinfo (ditto)
-+        HostAddress6    -- sin6_addr (ditto)
-+        ScopeID         -- sin6_scope_id (ditto)
-+  | SockAddrUnix
-+        String          -- sun_path
-+  | SockAddrCan
-+        Int32           -- can_ifindex (can be get by Network.BSD.ifNameToIndex "can0")
-+        -- TODO: Extend this to include transport protocol information
-+  deriving (Eq, Ord, Typeable)
-+
-+-- | Is the socket address type supported on this system?
-+isSupportedSockAddr :: SockAddr -> Bool
-+isSupportedSockAddr addr = case addr of
-+  SockAddrInet {} -> True
-+#if defined(IPV6_SOCKET_SUPPORT)
-+  SockAddrInet6 {} -> True
-+#endif
-+#if defined(DOMAIN_SOCKET_SUPPORT)
-+  SockAddrUnix{} -> True
-+#endif
-+#if defined(CAN_SOCKET_SUPPORT)
-+  SockAddrCan{} -> True
-+#endif
-+#if !(defined(IPV6_SOCKET_SUPPORT) \
-+      && defined(DOMAIN_SOCKET_SUPPORT) && defined(CAN_SOCKET_SUPPORT))
-+  _ -> False
-+#endif
-+
-+-- | Use a 'SockAddr' with a function requiring a pointer to a
-+-- 'SockAddr' and the length of that 'SockAddr'.
-+newSockAddr :: Channel -> IO SockAddr
-+newSockAddr ch = do
-+  sock <- getSockAddr ch
-+  let inet = inetAddrInt (sockInetAddress sock)
-+      port = sockPort sock
-+  return $ SockAddrInet (fromIntegral port) inet
-+
-+-- | Use a 'SockAddr' with a function requiring a pointer to a
-+-- 'SockAddr' and the length of that 'SockAddr'.
-+withSockAddr :: SockAddr -> (SocketAddress -> IO a) -> IO a
-+withSockAddr addr f = case addr of
-+  SockAddrInet port host ->
-+    f $ superCast $ mkInetSocketAddress
-+      (getByAddress . toJByteArray $ padWord8s 4 host)
-+      (fromIntegral port)
-+  SockAddrInet6 port _ (w1, w2, w3, w4) _ ->
-+    f $ superCast $ mkInetSocketAddress
-+      (getByAddress . toJByteArray $ concatMap (padWord8s 4) [w1, w2, w3, w4])
-+      (fromIntegral port)
-+  _ -> error "Network.Socket.Types.withSockAddr: Invalid socket address type."
-+  where toWord8s :: (Bits a, Integral a) => a -> [Word8]
-+        toWord8s 0 = []
-+        toWord8s n = fromIntegral (n .&. 255) : toWord8s (n `shiftR` 8)
-+
-+        padWord8s :: (Bits a, Integral a) => Int -> a -> [Word8]
-+        padWord8s n a = replicate (abs (n - length word8s)) 0 ++ word8s
-+          where word8s = reverse (toWord8s a)
-+
-+------------------------------------------------------------------------
-+
-+-- | The raw network byte order number is read using host byte order.
-+-- Therefore on little-endian architectures the byte order is swapped. For
-+-- example @127.0.0.1@ is represented as @0x0100007f@ on little-endian hosts
-+-- and as @0x7f000001@ on big-endian hosts.
-+--
-+-- For direct manipulation prefer 'hostAddressToTuple' and
-+-- 'tupleToHostAddress'.
-+type HostAddress = Word32
-+
-+-- | Converts 'HostAddress' to representation-independent IPv4 quadruple.
-+-- For example for @127.0.0.1@ the function will return @(0x7f, 0, 0, 1)@
-+-- regardless of host endianness.
-+hostAddressToTuple :: HostAddress -> (Word8, Word8, Word8, Word8)
-+hostAddressToTuple ha' =
-+    let ha = ha'
-+        byte i = fromIntegral (ha `shiftR` i) :: Word8
-+    in (byte 24, byte 16, byte 8, byte 0)
-+
-+-- | Converts IPv4 quadruple to 'HostAddress'.
-+tupleToHostAddress :: (Word8, Word8, Word8, Word8) -> HostAddress
-+tupleToHostAddress (b3, b2, b1, b0) =
-+    let x `sl` i = fromIntegral x `shiftL` i :: Word32
-+    in (b3 `sl` 24) .|. (b2 `sl` 16) .|. (b1 `sl` 8) .|. (b0 `sl` 0)
-+
-+#if defined(IPV6_SOCKET_SUPPORT)
-+-- | Independent of endianness. For example @::1@ is stored as @(0, 0, 0, 1)@.
-+--
-+-- For direct manipulation prefer 'hostAddress6ToTuple' and
-+-- 'tupleToHostAddress6'.
-+type HostAddress6 = (Word32, Word32, Word32, Word32)
-+
-+hostAddress6ToTuple :: HostAddress6 -> (Word16, Word16, Word16, Word16,
-+                                        Word16, Word16, Word16, Word16)
-+hostAddress6ToTuple (w3, w2, w1, w0) =
-+    let high, low :: Word32 -> Word16
-+        high w = fromIntegral (w `shiftR` 16)
-+        low w = fromIntegral w
-+    in (high w3, low w3, high w2, low w2, high w1, low w1, high w0, low w0)
-+
-+tupleToHostAddress6 :: (Word16, Word16, Word16, Word16,
-+                        Word16, Word16, Word16, Word16) -> HostAddress6
-+tupleToHostAddress6 (w7, w6, w5, w4, w3, w2, w1, w0) =
-+    let add :: Word16 -> Word16 -> Word32
-+        high `add` low = (fromIntegral high `shiftL` 16) .|. (fromIntegral low)
-+    in (w7 `add` w6, w5 `add` w4, w3 `add` w2, w1 `add` w0)
-+#endif
-+
-+-- ------------------------------------------------------------------------
-+-- -- Helper functions
-+
-+
-+foreign import java unsafe "@static eta.base.Utils.c_memset" memset
-+  :: Ptr a -> CInt -> CSize -> IO (Ptr a)
-+
-+-- | Zero a structure.
-+zeroMemory :: Ptr a -> CSize -> IO ()
-+zeroMemory dest nbytes = memset dest 0 (fromIntegral nbytes) >> return ()
-+
-+data {-# CLASS "java.net.SocketAddress" #-} SocketAddress =
-+  SA (Object# SocketAddress)
-+  deriving Class
-+
-+type instance Inherits SocketAddress = '[Object]
-+
-+data {-# CLASS "java.net.InetSocketAddress" #-} InetSocketAddress =
-+  ISA (Object# InetSocketAddress)
-+  deriving Class
-+
-+type instance Inherits InetSocketAddress = '[SocketAddress]
-+
-+data {-# CLASS "java.net.InetAddress" #-} InetAddress =
-+  IA (Object# InetAddress)
-+  deriving Class
-+
-+type instance Inherits InetAddress = '[Object]
-+
-+data {-# CLASS "java.net.InetAddress[]" #-} InetAddressArray =
-+  IArr (Object# InetAddressArray)
-+  deriving Class
-+
-+instance JArray InetAddress InetAddressArray
-+
-+data {-# CLASS "java.net.Inet4Address" #-} Inet4Address =
-+  I4A (Object# Inet4Address)
-+  deriving Class
-+
-+type instance Inherits Inet4Address = '[InetAddress]
-+
-+data {-# CLASS "java.net.Inet6Address" #-} Inet6Address =
-+  I6A (Object# Inet6Address)
-+  deriving Class
-+
-+type instance Inherits Inet6Address = '[InetAddress]
-+
-+foreign import java unsafe "@static java.net.InetAddress.getByAddress" getByAddress :: JByteArray -> InetAddress
-+
-+foreign import java unsafe "@new" mkInetSocketAddress
-+  :: InetAddress -> Int -> InetSocketAddress
-+
-+foreign import java unsafe "@static eta.network.Utils.getSockAddr" getSockAddr
-+  :: Channel -> IO InetSocketAddress
-+
-+foreign import java unsafe "getAddress" sockInetAddress
-+  :: InetSocketAddress -> InetAddress
-+
-+foreign import CALLCONV unsafe "getPort" sockPort :: InetSocketAddress -> Int
-+
-+toJByteArray :: [Word8] -> JByteArray
-+toJByteArray word8s = toJava bytes
-+  where bytes = map fromIntegral word8s :: [Byte]
-+
-+foreign import CALLCONV unsafe "@static eta.network.Utils.inetAddrInt"
-+  inetAddrInt :: InetAddress -> Word32
-+
-diff --git a/Network/Socket/Types.hsc b/Network/Socket/Types.hsc
-deleted file mode 100644
-index bed07d1..0000000
---- a/Network/Socket/Types.hsc
-+++ /dev/null
-@@ -1,1111 +0,0 @@
--{-# LANGUAGE DeriveDataTypeable #-}
--{-# LANGUAGE FlexibleInstances #-}
--{-# LANGUAGE ForeignFunctionInterface #-}
--
--#include "HsNet.h"
--
--module Network.Socket.Types
--    (
--    -- * Socket
--      Socket(..)
--    , sockFd
--    , sockFamily
--    , sockType
--    , sockProtocol
--    , sockStatus
--    , SocketStatus(..)
--
--    -- * Socket types
--    , SocketType(..)
--    , isSupportedSocketType
--    , packSocketType
--    , packSocketType'
--    , packSocketTypeOrThrow
--    , unpackSocketType
--    , unpackSocketType'
--
--    -- * Family
--    , Family(..)
--    , isSupportedFamily
--    , packFamily
--    , unpackFamily
--
--    -- * Socket addresses
--    , SockAddr(..)
--    , isSupportedSockAddr
--    , HostAddress
--    , hostAddressToTuple
--    , tupleToHostAddress
--#if defined(IPV6_SOCKET_SUPPORT)
--    , HostAddress6
--    , hostAddress6ToTuple
--    , tupleToHostAddress6
--    , FlowInfo
--    , ScopeID
--#endif
--    , peekSockAddr
--    , pokeSockAddr
--    , sizeOfSockAddr
--    , sizeOfSockAddrByFamily
--    , withSockAddr
--    , withNewSockAddr
--
--    -- * Unsorted
--    , ProtocolNumber
--    , PortNumber(..)
--
--    -- * Low-level helpers
--    , zeroMemory
--    ) where
--
--import Control.Concurrent.MVar
--import Control.Monad
--import Data.Bits
--import Data.Maybe
--import Data.Ratio
--import Data.Typeable
--import Data.Word
--import Data.Int
--import Foreign.C
--import Foreign.Marshal.Alloc
--import Foreign.Marshal.Array
--import Foreign.Ptr
--import Foreign.Storable
--
---- | Represents a socket.  The fields are, respectively:
----
----   * File descriptor
----   * Socket family
----   * Socket type
----   * Protocol number
----   * Status flag
----
----   If you are calling the 'MkSocket' constructor directly you should ensure
----   you have called 'Network.withSocketsDo' and that the file descriptor is
----   in non-blocking mode. See 'Network.Socket.setNonBlockIfNeeded'.
--data Socket
--  = MkSocket
--            CInt                 -- File Descriptor
--            Family
--            SocketType
--            ProtocolNumber       -- Protocol Number
--            (MVar SocketStatus)  -- Status Flag
--  deriving Typeable
--
--sockFd :: Socket -> CInt
--sockFd       (MkSocket n _ _ _ _) = n
--
--sockFamily :: Socket -> Family
--sockFamily   (MkSocket _ f _ _ _) = f
--
--sockType :: Socket -> SocketType
--sockType     (MkSocket _ _ t _ _) = t
--
--sockProtocol :: Socket -> ProtocolNumber
--sockProtocol (MkSocket _ _ _ p _) = p
--
--sockStatus :: Socket -> MVar SocketStatus
--sockStatus   (MkSocket _ _ _ _ s) = s
--
--instance Eq Socket where
--  (MkSocket _ _ _ _ m1) == (MkSocket _ _ _ _ m2) = m1 == m2
--
--instance Show Socket where
--  showsPrec _n (MkSocket fd _ _ _ _) =
--        showString "<socket: " . shows fd . showString ">"
--
--type ProtocolNumber = CInt
--
---- | The status of the socket as /determined by this library/, not
---- necessarily reflecting the state of the connection itself.
----
---- For example, the 'Closed' status is applied when the 'close'
---- function is called.
--data SocketStatus
--  -- Returned Status    Function called
--  = NotConnected        -- ^ Newly created, unconnected socket
+ 
+ type ProtocolNumber = CInt
+ 
+@@ -124,12 +136,12 @@ type ProtocolNumber = CInt
+ data SocketStatus
+   -- Returned Status    Function called
+   = NotConnected        -- ^ Newly created, unconnected socket
 -  | Bound               -- ^ Bound, via 'bind'
--  | Listening           -- ^ Listening, via 'listen'
--  | Connected           -- ^ Connected or accepted, via 'connect' or 'accept'
--  | ConvertedToHandle   -- ^ Is now a 'Handle' (via 'socketToHandle'), don't touch
--  | Closed              -- ^ Closed was closed by 'close'
++  | Bound SockAddr      -- ^ Bound, via 'bind'
+   | Listening           -- ^ Listening, via 'listen'
+   | Connected           -- ^ Connected or accepted, via 'connect' or 'accept'
+   | ConvertedToHandle   -- ^ Is now a 'Handle' (via 'socketToHandle'), don't touch
+   | Closed              -- ^ Closed was closed by 'close'
 -    deriving (Eq, Show, Typeable)
--
-------------------------------------------------------------------------------
---- Socket types
--
---- There are a few possible ways to do this.  The first is convert the
---- structs used in the C library into an equivalent Haskell type. An
---- other possible implementation is to keep all the internals in the C
---- code and use an Int## and a status flag. The second method is used
---- here since a lot of the C structures are not required to be
---- manipulated.
--
---- Originally the status was non-mutable so we had to return a new
---- socket each time we changed the status.  This version now uses
---- mutable variables to avoid the need to do this.  The result is a
---- cleaner interface and better security since the application
---- programmer now can't circumvent the status information to perform
---- invalid operations on sockets.
--
---- | Socket Types.
----
---- The existence of a constructor does not necessarily imply that that
---- socket type is supported on your system: see 'isSupportedSocketType'.
--data SocketType
--        = NoSocketType -- ^ 0, used in getAddrInfo hints, for example
--        | Stream -- ^ SOCK_STREAM
--        | Datagram -- ^ SOCK_DGRAM
--        | Raw -- ^ SOCK_RAW
--        | RDM -- ^ SOCK_RDM
--        | SeqPacket -- ^ SOCK_SEQPACKET
--        deriving (Eq, Ord, Read, Show, Typeable)
--
---- | Does the SOCK_ constant corresponding to the given SocketType exist on
---- this system?
--isSupportedSocketType :: SocketType -> Bool
--isSupportedSocketType = isJust . packSocketType'
--
---- | Find the SOCK_ constant corresponding to the SocketType value.
--packSocketType' :: SocketType -> Maybe CInt
--packSocketType' stype = case Just stype of
--    -- the Just above is to disable GHC's overlapping pattern
--    -- detection: see comments for packSocketOption
++    deriving (Eq, Typeable)
+ 
+ -----------------------------------------------------------------------------
+ -- Socket types
+@@ -159,6 +171,7 @@ data SocketType
+         | Raw -- ^ SOCK_RAW
+         | RDM -- ^ SOCK_RDM
+         | SeqPacket -- ^ SOCK_SEQPACKET
++        | ServerSocket SocketType -- ^ ServerSocket
+         deriving (Eq, Ord, Read, Show, Typeable)
+ 
+ -- | Does the SOCK_ constant corresponding to the given SocketType exist on
+@@ -171,23 +184,11 @@ packSocketType' :: SocketType -> Maybe CInt
+ packSocketType' stype = case Just stype of
+     -- the Just above is to disable GHC's overlapping pattern
+     -- detection: see comments for packSocketOption
 -    Just NoSocketType -> Just 0
 -#ifdef SOCK_STREAM
 -    Just Stream -> Just #const SOCK_STREAM
@@ -6768,672 +1845,94 @@ index bed07d1..0000000
 -    Just SeqPacket -> Just #const SOCK_SEQPACKET
 -#endif
 -    _ -> Nothing
--
--packSocketType :: SocketType -> CInt
--packSocketType stype = fromMaybe (error errMsg) (packSocketType' stype)
--  where
--    errMsg = concat ["Network.Socket.packSocketType: ",
--                     "socket type ", show stype, " unsupported on this system"]
--
---- | Try packSocketType' on the SocketType, if it fails throw an error with
---- message starting "Network.Socket." ++ the String parameter
--packSocketTypeOrThrow :: String -> SocketType -> IO CInt
--packSocketTypeOrThrow caller stype = maybe err return (packSocketType' stype)
-- where
--  err = ioError . userError . concat $ ["Network.Socket.", caller, ": ",
--    "socket type ", show stype, " unsupported on this system"]
--
--
--unpackSocketType:: CInt -> Maybe SocketType
--unpackSocketType t = case t of
--        0 -> Just NoSocketType
--#ifdef SOCK_STREAM
++    Just NoSocketType     -> Just 0
++    Just Stream           -> Just 1
++    Just Datagram         -> Just 2
++    Just (ServerSocket _) -> Just 3
++    _                     -> Nothing
+ 
+ packSocketType :: SocketType -> CInt
+ packSocketType stype = fromMaybe (error errMsg) (packSocketType' stype)
+@@ -208,10 +209,13 @@ unpackSocketType:: CInt -> Maybe SocketType
+ unpackSocketType t = case t of
+         0 -> Just NoSocketType
+ #ifdef SOCK_STREAM
 -        (#const SOCK_STREAM) -> Just Stream
--#endif
--#ifdef SOCK_DGRAM
++        1 -> Just Stream
+ #endif
+ #ifdef SOCK_DGRAM
 -        (#const SOCK_DGRAM) -> Just Datagram
--#endif
--#ifdef SOCK_RAW
--        (#const SOCK_RAW) -> Just Raw
--#endif
--#ifdef SOCK_RDM
--        (#const SOCK_RDM) -> Just RDM
--#endif
--#ifdef SOCK_SEQPACKET
--        (#const SOCK_SEQPACKET) -> Just SeqPacket
--#endif
--        _ -> Nothing
--
---- | Try unpackSocketType on the CInt, if it fails throw an error with
---- message starting "Network.Socket." ++ the String parameter
--unpackSocketType' :: String -> CInt -> IO SocketType
--unpackSocketType' caller ty = maybe err return (unpackSocketType ty)
-- where
--  err = ioError . userError . concat $ ["Network.Socket.", caller, ": ",
--    "socket type ", show ty, " unsupported on this system"]
--
--------------------------------------------------------------------------
---- Protocol Families.
--
---- | Address families.
----
---- A constructor being present here does not mean it is supported by the
---- operating system: see 'isSupportedFamily'.
--data Family
--    = AF_UNSPEC           -- unspecified
--    | AF_UNIX             -- local to host (pipes, portals
--    | AF_INET             -- internetwork: UDP, TCP, etc
--    | AF_INET6            -- Internet Protocol version 6
--    | AF_IMPLINK          -- arpanet imp addresses
--    | AF_PUP              -- pup protocols: e.g. BSP
--    | AF_CHAOS            -- mit CHAOS protocols
--    | AF_NS               -- XEROX NS protocols
--    | AF_NBS              -- nbs protocols
--    | AF_ECMA             -- european computer manufacturers
--    | AF_DATAKIT          -- datakit protocols
--    | AF_CCITT            -- CCITT protocols, X.25 etc
--    | AF_SNA              -- IBM SNA
--    | AF_DECnet           -- DECnet
--    | AF_DLI              -- Direct data link interface
--    | AF_LAT              -- LAT
--    | AF_HYLINK           -- NSC Hyperchannel
--    | AF_APPLETALK        -- Apple Talk
--    | AF_ROUTE            -- Internal Routing Protocol
--    | AF_NETBIOS          -- NetBios-style addresses
--    | AF_NIT              -- Network Interface Tap
--    | AF_802              -- IEEE 802.2, also ISO 8802
--    | AF_ISO              -- ISO protocols
--    | AF_OSI              -- umbrella of all families used by OSI
--    | AF_NETMAN           -- DNA Network Management
--    | AF_X25              -- CCITT X.25
--    | AF_AX25
--    | AF_OSINET           -- AFI
--    | AF_GOSSIP           -- US Government OSI
--    | AF_IPX              -- Novell Internet Protocol
--    | Pseudo_AF_XTP       -- eXpress Transfer Protocol (no AF)
--    | AF_CTF              -- Common Trace Facility
--    | AF_WAN              -- Wide Area Network protocols
--    | AF_SDL              -- SGI Data Link for DLPI
--    | AF_NETWARE
--    | AF_NDD
--    | AF_INTF             -- Debugging use only
--    | AF_COIP             -- connection-oriented IP, aka ST II
--    | AF_CNT              -- Computer Network Technology
--    | Pseudo_AF_RTIP      -- Help Identify RTIP packets
--    | Pseudo_AF_PIP       -- Help Identify PIP packets
--    | AF_SIP              -- Simple Internet Protocol
--    | AF_ISDN             -- Integrated Services Digital Network
--    | Pseudo_AF_KEY       -- Internal key-management function
--    | AF_NATM             -- native ATM access
--    | AF_ARP              -- (rev.) addr. res. prot. (RFC 826)
--    | Pseudo_AF_HDRCMPLT  -- Used by BPF to not rewrite hdrs in iface output
--    | AF_ENCAP
--    | AF_LINK             -- Link layer interface
--    | AF_RAW              -- Link layer interface
--    | AF_RIF              -- raw interface
--    | AF_NETROM           -- Amateur radio NetROM
--    | AF_BRIDGE           -- multiprotocol bridge
--    | AF_ATMPVC           -- ATM PVCs
--    | AF_ROSE             -- Amateur Radio X.25 PLP
--    | AF_NETBEUI          -- 802.2LLC
--    | AF_SECURITY         -- Security callback pseudo AF
--    | AF_PACKET           -- Packet family
--    | AF_ASH              -- Ash
--    | AF_ECONET           -- Acorn Econet
--    | AF_ATMSVC           -- ATM SVCs
--    | AF_IRDA             -- IRDA sockets
--    | AF_PPPOX            -- PPPoX sockets
--    | AF_WANPIPE          -- Wanpipe API sockets
--    | AF_BLUETOOTH        -- bluetooth sockets
--    | AF_CAN              -- Controller Area Network
--      deriving (Eq, Ord, Read, Show)
--
--packFamily :: Family -> CInt
--packFamily f = case packFamily' f of
--    Just fam -> fam
--    Nothing -> error $
--               "Network.Socket.packFamily: unsupported address family: " ++
--               show f
--
---- | Does the AF_ constant corresponding to the given family exist on this
---- system?
--isSupportedFamily :: Family -> Bool
--isSupportedFamily = isJust . packFamily'
--
--packFamily' :: Family -> Maybe CInt
--packFamily' f = case Just f of
--    -- the Just above is to disable GHC's overlapping pattern
--    -- detection: see comments for packSocketOption
++        2 -> Just Datagram
++#endif
++#ifdef SOCK_STREAM
++        3 -> Just (ServerSocket Stream)
+ #endif
+ #ifdef SOCK_RAW
+         (#const SOCK_RAW) -> Just Raw
+@@ -324,15 +328,15 @@ packFamily' :: Family -> Maybe CInt
+ packFamily' f = case Just f of
+     -- the Just above is to disable GHC's overlapping pattern
+     -- detection: see comments for packSocketOption
 -    Just AF_UNSPEC -> Just #const AF_UNSPEC
--#ifdef AF_UNIX
--    Just AF_UNIX -> Just #const AF_UNIX
--#endif
++    Just AF_UNSPEC -> Just 0
+ #ifdef AF_UNIX
+     Just AF_UNIX -> Just #const AF_UNIX
+ #endif
 -#ifdef AF_INET
 -    Just AF_INET -> Just #const AF_INET
--#endif
++#ifdef DEF_AF_INET
++    Just AF_INET -> Just 1
+ #endif
 -#ifdef AF_INET6
 -    Just AF_INET6 -> Just #const AF_INET6
--#endif
--#ifdef AF_IMPLINK
--    Just AF_IMPLINK -> Just #const AF_IMPLINK
--#endif
--#ifdef AF_PUP
--    Just AF_PUP -> Just #const AF_PUP
--#endif
--#ifdef AF_CHAOS
--    Just AF_CHAOS -> Just #const AF_CHAOS
--#endif
--#ifdef AF_NS
--    Just AF_NS -> Just #const AF_NS
--#endif
--#ifdef AF_NBS
--    Just AF_NBS -> Just #const AF_NBS
--#endif
--#ifdef AF_ECMA
--    Just AF_ECMA -> Just #const AF_ECMA
--#endif
--#ifdef AF_DATAKIT
--    Just AF_DATAKIT -> Just #const AF_DATAKIT
--#endif
--#ifdef AF_CCITT
--    Just AF_CCITT -> Just #const AF_CCITT
--#endif
--#ifdef AF_SNA
--    Just AF_SNA -> Just #const AF_SNA
--#endif
--#ifdef AF_DECnet
--    Just AF_DECnet -> Just #const AF_DECnet
--#endif
--#ifdef AF_DLI
--    Just AF_DLI -> Just #const AF_DLI
--#endif
--#ifdef AF_LAT
--    Just AF_LAT -> Just #const AF_LAT
--#endif
--#ifdef AF_HYLINK
--    Just AF_HYLINK -> Just #const AF_HYLINK
--#endif
--#ifdef AF_APPLETALK
--    Just AF_APPLETALK -> Just #const AF_APPLETALK
--#endif
--#ifdef AF_ROUTE
--    Just AF_ROUTE -> Just #const AF_ROUTE
--#endif
--#ifdef AF_NETBIOS
--    Just AF_NETBIOS -> Just #const AF_NETBIOS
--#endif
--#ifdef AF_NIT
--    Just AF_NIT -> Just #const AF_NIT
--#endif
--#ifdef AF_802
--    Just AF_802 -> Just #const AF_802
--#endif
--#ifdef AF_ISO
--    Just AF_ISO -> Just #const AF_ISO
--#endif
--#ifdef AF_OSI
--    Just AF_OSI -> Just #const AF_OSI
--#endif
--#ifdef AF_NETMAN
--    Just AF_NETMAN -> Just #const AF_NETMAN
--#endif
--#ifdef AF_X25
--    Just AF_X25 -> Just #const AF_X25
--#endif
--#ifdef AF_AX25
--    Just AF_AX25 -> Just #const AF_AX25
--#endif
--#ifdef AF_OSINET
--    Just AF_OSINET -> Just #const AF_OSINET
--#endif
--#ifdef AF_GOSSIP
--    Just AF_GOSSIP -> Just #const AF_GOSSIP
--#endif
--#ifdef AF_IPX
--    Just AF_IPX -> Just #const AF_IPX
--#endif
--#ifdef Pseudo_AF_XTP
--    Just Pseudo_AF_XTP -> Just #const Pseudo_AF_XTP
--#endif
--#ifdef AF_CTF
--    Just AF_CTF -> Just #const AF_CTF
--#endif
--#ifdef AF_WAN
--    Just AF_WAN -> Just #const AF_WAN
--#endif
--#ifdef AF_SDL
--    Just AF_SDL -> Just #const AF_SDL
--#endif
--#ifdef AF_NETWARE
--    Just AF_NETWARE -> Just #const AF_NETWARE
--#endif
--#ifdef AF_NDD
--    Just AF_NDD -> Just #const AF_NDD
--#endif
--#ifdef AF_INTF
--    Just AF_INTF -> Just #const AF_INTF
--#endif
--#ifdef AF_COIP
--    Just AF_COIP -> Just #const AF_COIP
--#endif
--#ifdef AF_CNT
--    Just AF_CNT -> Just #const AF_CNT
--#endif
--#ifdef Pseudo_AF_RTIP
--    Just Pseudo_AF_RTIP -> Just #const Pseudo_AF_RTIP
--#endif
--#ifdef Pseudo_AF_PIP
--    Just Pseudo_AF_PIP -> Just #const Pseudo_AF_PIP
--#endif
--#ifdef AF_SIP
--    Just AF_SIP -> Just #const AF_SIP
--#endif
--#ifdef AF_ISDN
--    Just AF_ISDN -> Just #const AF_ISDN
--#endif
--#ifdef Pseudo_AF_KEY
--    Just Pseudo_AF_KEY -> Just #const Pseudo_AF_KEY
--#endif
--#ifdef AF_NATM
--    Just AF_NATM -> Just #const AF_NATM
--#endif
--#ifdef AF_ARP
--    Just AF_ARP -> Just #const AF_ARP
--#endif
--#ifdef Pseudo_AF_HDRCMPLT
--    Just Pseudo_AF_HDRCMPLT -> Just #const Pseudo_AF_HDRCMPLT
--#endif
--#ifdef AF_ENCAP
--    Just AF_ENCAP -> Just #const AF_ENCAP
--#endif
--#ifdef AF_LINK
--    Just AF_LINK -> Just #const AF_LINK
--#endif
--#ifdef AF_RAW
--    Just AF_RAW -> Just #const AF_RAW
--#endif
--#ifdef AF_RIF
--    Just AF_RIF -> Just #const AF_RIF
--#endif
--#ifdef AF_NETROM
--    Just AF_NETROM -> Just #const AF_NETROM
--#endif
--#ifdef AF_BRIDGE
--    Just AF_BRIDGE -> Just #const AF_BRIDGE
--#endif
--#ifdef AF_ATMPVC
--    Just AF_ATMPVC -> Just #const AF_ATMPVC
--#endif
--#ifdef AF_ROSE
--    Just AF_ROSE -> Just #const AF_ROSE
--#endif
--#ifdef AF_NETBEUI
--    Just AF_NETBEUI -> Just #const AF_NETBEUI
--#endif
--#ifdef AF_SECURITY
--    Just AF_SECURITY -> Just #const AF_SECURITY
--#endif
--#ifdef AF_PACKET
--    Just AF_PACKET -> Just #const AF_PACKET
--#endif
--#ifdef AF_ASH
--    Just AF_ASH -> Just #const AF_ASH
--#endif
--#ifdef AF_ECONET
--    Just AF_ECONET -> Just #const AF_ECONET
--#endif
--#ifdef AF_ATMSVC
--    Just AF_ATMSVC -> Just #const AF_ATMSVC
--#endif
--#ifdef AF_IRDA
--    Just AF_IRDA -> Just #const AF_IRDA
--#endif
--#ifdef AF_PPPOX
--    Just AF_PPPOX -> Just #const AF_PPPOX
--#endif
--#ifdef AF_WANPIPE
--    Just AF_WANPIPE -> Just #const AF_WANPIPE
--#endif
--#ifdef AF_BLUETOOTH
--    Just AF_BLUETOOTH -> Just #const AF_BLUETOOTH
--#endif
--#ifdef AF_CAN
--    Just AF_CAN -> Just #const AF_CAN
--#endif
--    _ -> Nothing
--
----------- ----------
--
--unpackFamily :: CInt -> Family
--unpackFamily f = case f of
++#ifdef DEF_AF_INET6
++    Just AF_INET6 -> Just 2
+ #endif
+ #ifdef AF_IMPLINK
+     Just AF_IMPLINK -> Just #const AF_IMPLINK
+@@ -526,15 +530,15 @@ packFamily' f = case Just f of
+ 
+ unpackFamily :: CInt -> Family
+ unpackFamily f = case f of
 -        (#const AF_UNSPEC) -> AF_UNSPEC
--#ifdef AF_UNIX
--        (#const AF_UNIX) -> AF_UNIX
--#endif
++        0 -> AF_UNSPEC
+ #ifdef AF_UNIX
+         (#const AF_UNIX) -> AF_UNIX
+ #endif
 -#ifdef AF_INET
 -        (#const AF_INET) -> AF_INET
--#endif
++#ifdef DEF_AF_INET
++        1 -> AF_INET
+ #endif
 -#ifdef AF_INET6
 -        (#const AF_INET6) -> AF_INET6
--#endif
--#ifdef AF_IMPLINK
--        (#const AF_IMPLINK) -> AF_IMPLINK
--#endif
--#ifdef AF_PUP
--        (#const AF_PUP) -> AF_PUP
--#endif
--#ifdef AF_CHAOS
--        (#const AF_CHAOS) -> AF_CHAOS
--#endif
--#ifdef AF_NS
--        (#const AF_NS) -> AF_NS
--#endif
--#ifdef AF_NBS
--        (#const AF_NBS) -> AF_NBS
--#endif
--#ifdef AF_ECMA
--        (#const AF_ECMA) -> AF_ECMA
--#endif
--#ifdef AF_DATAKIT
--        (#const AF_DATAKIT) -> AF_DATAKIT
--#endif
--#ifdef AF_CCITT
--        (#const AF_CCITT) -> AF_CCITT
--#endif
--#ifdef AF_SNA
--        (#const AF_SNA) -> AF_SNA
--#endif
--#ifdef AF_DECnet
--        (#const AF_DECnet) -> AF_DECnet
--#endif
--#ifdef AF_DLI
--        (#const AF_DLI) -> AF_DLI
--#endif
--#ifdef AF_LAT
--        (#const AF_LAT) -> AF_LAT
--#endif
--#ifdef AF_HYLINK
--        (#const AF_HYLINK) -> AF_HYLINK
--#endif
--#ifdef AF_APPLETALK
--        (#const AF_APPLETALK) -> AF_APPLETALK
--#endif
--#ifdef AF_ROUTE
--        (#const AF_ROUTE) -> AF_ROUTE
--#endif
--#ifdef AF_NETBIOS
--        (#const AF_NETBIOS) -> AF_NETBIOS
--#endif
--#ifdef AF_NIT
--        (#const AF_NIT) -> AF_NIT
--#endif
--#ifdef AF_802
--        (#const AF_802) -> AF_802
--#endif
--#ifdef AF_ISO
--        (#const AF_ISO) -> AF_ISO
--#endif
--#ifdef AF_OSI
--# if (!defined(AF_ISO)) || (defined(AF_ISO) && (AF_ISO != AF_OSI))
--        (#const AF_OSI) -> AF_OSI
--# endif
--#endif
--#ifdef AF_NETMAN
--        (#const AF_NETMAN) -> AF_NETMAN
--#endif
--#ifdef AF_X25
--        (#const AF_X25) -> AF_X25
--#endif
--#ifdef AF_AX25
--        (#const AF_AX25) -> AF_AX25
--#endif
--#ifdef AF_OSINET
--        (#const AF_OSINET) -> AF_OSINET
--#endif
--#ifdef AF_GOSSIP
--        (#const AF_GOSSIP) -> AF_GOSSIP
--#endif
--#if defined(AF_IPX) && (!defined(AF_NS) || AF_NS != AF_IPX)
--        (#const AF_IPX) -> AF_IPX
--#endif
--#ifdef Pseudo_AF_XTP
--        (#const Pseudo_AF_XTP) -> Pseudo_AF_XTP
--#endif
--#ifdef AF_CTF
--        (#const AF_CTF) -> AF_CTF
--#endif
--#ifdef AF_WAN
--        (#const AF_WAN) -> AF_WAN
--#endif
--#ifdef AF_SDL
--        (#const AF_SDL) -> AF_SDL
--#endif
--#ifdef AF_NETWARE
--        (#const AF_NETWARE) -> AF_NETWARE
--#endif
--#ifdef AF_NDD
--        (#const AF_NDD) -> AF_NDD
--#endif
--#ifdef AF_INTF
--        (#const AF_INTF) -> AF_INTF
--#endif
--#ifdef AF_COIP
--        (#const AF_COIP) -> AF_COIP
--#endif
--#ifdef AF_CNT
--        (#const AF_CNT) -> AF_CNT
--#endif
--#ifdef Pseudo_AF_RTIP
--        (#const Pseudo_AF_RTIP) -> Pseudo_AF_RTIP
--#endif
--#ifdef Pseudo_AF_PIP
--        (#const Pseudo_AF_PIP) -> Pseudo_AF_PIP
--#endif
--#ifdef AF_SIP
--        (#const AF_SIP) -> AF_SIP
--#endif
--#ifdef AF_ISDN
--        (#const AF_ISDN) -> AF_ISDN
--#endif
--#ifdef Pseudo_AF_KEY
--        (#const Pseudo_AF_KEY) -> Pseudo_AF_KEY
--#endif
--#ifdef AF_NATM
--        (#const AF_NATM) -> AF_NATM
--#endif
--#ifdef AF_ARP
--        (#const AF_ARP) -> AF_ARP
--#endif
--#ifdef Pseudo_AF_HDRCMPLT
--        (#const Pseudo_AF_HDRCMPLT) -> Pseudo_AF_HDRCMPLT
--#endif
--#ifdef AF_ENCAP
--        (#const AF_ENCAP) -> AF_ENCAP
--#endif
--#ifdef AF_LINK
--        (#const AF_LINK) -> AF_LINK
--#endif
--#ifdef AF_RAW
--        (#const AF_RAW) -> AF_RAW
--#endif
--#ifdef AF_RIF
--        (#const AF_RIF) -> AF_RIF
--#endif
--#ifdef AF_NETROM
--        (#const AF_NETROM) -> AF_NETROM
--#endif
--#ifdef AF_BRIDGE
--        (#const AF_BRIDGE) -> AF_BRIDGE
--#endif
--#ifdef AF_ATMPVC
--        (#const AF_ATMPVC) -> AF_ATMPVC
--#endif
--#ifdef AF_ROSE
--        (#const AF_ROSE) -> AF_ROSE
--#endif
--#ifdef AF_NETBEUI
--        (#const AF_NETBEUI) -> AF_NETBEUI
--#endif
--#ifdef AF_SECURITY
--        (#const AF_SECURITY) -> AF_SECURITY
--#endif
--#ifdef AF_PACKET
--        (#const AF_PACKET) -> AF_PACKET
--#endif
--#ifdef AF_ASH
--        (#const AF_ASH) -> AF_ASH
--#endif
--#ifdef AF_ECONET
--        (#const AF_ECONET) -> AF_ECONET
--#endif
--#ifdef AF_ATMSVC
--        (#const AF_ATMSVC) -> AF_ATMSVC
--#endif
--#ifdef AF_IRDA
--        (#const AF_IRDA) -> AF_IRDA
--#endif
--#ifdef AF_PPPOX
--        (#const AF_PPPOX) -> AF_PPPOX
--#endif
--#ifdef AF_WANPIPE
--        (#const AF_WANPIPE) -> AF_WANPIPE
--#endif
--#ifdef AF_BLUETOOTH
--        (#const AF_BLUETOOTH) -> AF_BLUETOOTH
--#endif
--#ifdef AF_CAN
--        (#const AF_CAN) -> AF_CAN
--#endif
--        unknown -> error $
--          "Network.Socket.Types.unpackFamily: unknown address family: " ++
--          show unknown
--
--------------------------------------------------------------------------
---- Port Numbers
--
---- | Use the @Num@ instance (i.e. use a literal) to create a
---- @PortNumber@ value with the correct network-byte-ordering. You
---- should not use the PortNum constructor. It will be removed in the
---- next release.
----
---- >>> 1 :: PortNumber
---- 1
---- >>> read "1" :: PortNumber
---- 1
--newtype PortNumber = PortNum Word16 deriving (Eq, Ord, Typeable)
---- newtyped to prevent accidental use of sane-looking
---- port numbers that haven't actually been converted to
---- network-byte-order first.
--
--{-# DEPRECATED PortNum "Do not use the PortNum constructor. Use the Num instance. PortNum will be removed in the next release." #-}
--
--instance Show PortNumber where
--  showsPrec p pn = showsPrec p (portNumberToInt pn)
--
--instance Read PortNumber where
--  readsPrec n = map (\(x,y) -> (intToPortNumber x, y)) . readsPrec n
--
--intToPortNumber :: Int -> PortNumber
++#ifdef DEF_AF_INET6
++        2 -> AF_INET6
+ #endif
+ #ifdef AF_IMPLINK
+         (#const AF_IMPLINK) -> AF_IMPLINK
+@@ -754,15 +758,10 @@ instance Read PortNumber where
+   readsPrec n = map (\(x,y) -> (intToPortNumber x, y)) . readsPrec n
+ 
+ intToPortNumber :: Int -> PortNumber
 -intToPortNumber v = PortNum (htons (fromIntegral v))
--
--portNumberToInt :: PortNumber -> Int
++intToPortNumber v = PortNum (fromIntegral v)
+ 
+ portNumberToInt :: PortNumber -> Int
 -portNumberToInt (PortNum po) = fromIntegral (ntohs po)
 -
 -foreign import CALLCONV unsafe "ntohs" ntohs :: Word16 -> Word16
 -foreign import CALLCONV unsafe "htons" htons :: Word16 -> Word16
 -foreign import CALLCONV unsafe "ntohl" ntohl :: Word32 -> Word32
 -foreign import CALLCONV unsafe "htonl" htonl :: Word32 -> Word32
--
--instance Enum PortNumber where
--    toEnum   = intToPortNumber
--    fromEnum = portNumberToInt
--
--instance Num PortNumber where
--   fromInteger i = intToPortNumber (fromInteger i)
--    -- for completeness.
--   (+) x y   = intToPortNumber (portNumberToInt x + portNumberToInt y)
--   (-) x y   = intToPortNumber (portNumberToInt x - portNumberToInt y)
--   negate x  = intToPortNumber (-portNumberToInt x)
--   (*) x y   = intToPortNumber (portNumberToInt x * portNumberToInt y)
--   abs n     = intToPortNumber (abs (portNumberToInt n))
--   signum n  = intToPortNumber (signum (portNumberToInt n))
--
--instance Real PortNumber where
--    toRational x = toInteger x % 1
--
--instance Integral PortNumber where
--    quotRem a b = let (c,d) = quotRem (portNumberToInt a) (portNumberToInt b) in
--                  (intToPortNumber c, intToPortNumber d)
--    toInteger a = toInteger (portNumberToInt a)
--
--instance Storable PortNumber where
--   sizeOf    _ = sizeOf    (undefined :: Word16)
--   alignment _ = alignment (undefined :: Word16)
--   poke p (PortNum po) = poke (castPtr p) po
--   peek p = PortNum `liftM` peek (castPtr p)
--
--------------------------------------------------------------------------
---- Socket addresses
--
---- The scheme used for addressing sockets is somewhat quirky. The
---- calls in the BSD socket API that need to know the socket address
---- all operate in terms of struct sockaddr, a `virtual' type of
---- socket address.
--
---- The Internet family of sockets are addressed as struct sockaddr_in,
---- so when calling functions that operate on struct sockaddr, we have
---- to type cast the Internet socket address into a struct sockaddr.
---- Instances of the structure for different families might *not* be
---- the same size. Same casting is required of other families of
---- sockets such as Xerox NS. Similarly for Unix domain sockets.
--
---- To represent these socket addresses in Haskell-land, we do what BSD
---- didn't do, and use a union/algebraic type for the different
---- families. Currently only Unix domain sockets and the Internet
---- families are supported.
--
--#if defined(IPV6_SOCKET_SUPPORT)
--type FlowInfo = Word32
--type ScopeID = Word32
--#endif
--
---- | The existence of a constructor does not necessarily imply that
---- that socket address type is supported on your system: see
---- 'isSupportedSockAddr'.
--data SockAddr       -- C Names
--  = SockAddrInet
--    PortNumber  -- sin_port  (network byte order)
--    HostAddress -- sin_addr  (ditto)
--  | SockAddrInet6
--        PortNumber      -- sin6_port (network byte order)
--        FlowInfo        -- sin6_flowinfo (ditto)
--        HostAddress6    -- sin6_addr (ditto)
--        ScopeID         -- sin6_scope_id (ditto)
--  | SockAddrUnix
--        String          -- sun_path
--  | SockAddrCan
--        Int32           -- can_ifindex (can be get by Network.BSD.ifNameToIndex "can0")
--        -- TODO: Extend this to include transport protocol information
--  deriving (Eq, Ord, Typeable)
--
---- | Is the socket address type supported on this system?
--isSupportedSockAddr :: SockAddr -> Bool
--isSupportedSockAddr addr = case addr of
--  SockAddrInet {} -> True
--#if defined(IPV6_SOCKET_SUPPORT)
--  SockAddrInet6 {} -> True
--#endif
--#if defined(DOMAIN_SOCKET_SUPPORT)
--  SockAddrUnix{} -> True
--#endif
--#if defined(CAN_SOCKET_SUPPORT)
--  SockAddrCan{} -> True
--#endif
--#if !(defined(IPV6_SOCKET_SUPPORT) \
--      && defined(DOMAIN_SOCKET_SUPPORT) && defined(CAN_SOCKET_SUPPORT))
--  _ -> False
--#endif
--
++portNumberToInt (PortNum po) = fromIntegral po
+ 
+ instance Enum PortNumber where
+     toEnum   = intToPortNumber
+@@ -854,151 +853,35 @@ isSupportedSockAddr addr = case addr of
+   _ -> False
+ #endif
+ 
 -#if defined(WITH_WINSOCK)
 -type CSaFamily = (#type unsigned short)
 -#elif defined(darwin_HOST_OS)
@@ -7477,8 +1976,8 @@ index bed07d1..0000000
 -    "Network.Socket.Types.sizeOfSockAddrByFamily: address family '" ++
 -    show family ++ "' not supported."
 -
---- | Use a 'SockAddr' with a function requiring a pointer to a
---- 'SockAddr' and the length of that 'SockAddr'.
+ -- | Use a 'SockAddr' with a function requiring a pointer to a
+ -- 'SockAddr' and the length of that 'SockAddr'.
 -withSockAddr :: SockAddr -> (Ptr SockAddr -> Int -> IO a) -> IO a
 -withSockAddr addr f = do
 -    let sz = sizeOfSockAddr addr
@@ -7548,7 +2047,13 @@ index bed07d1..0000000
 -#endif
 -    (#poke struct sockaddr_can, can_ifindex) p ifIndex
 -#endif
--
++newSockAddr :: Channel -> IO SockAddr
++newSockAddr ch = do
++  sock <- getSockAddr ch
++  let inet = inetAddrInt (sockInetAddress sock)
++      port = sockPort sock
++  return $ SockAddrInet (fromIntegral port) inet
+ 
 --- | Read a 'SockAddr' from the given memory location.
 -peekSockAddr :: Ptr SockAddr -> IO SockAddr
 -peekSockAddr p = do
@@ -7579,54 +2084,51 @@ index bed07d1..0000000
 -    _ -> ioError $ userError $
 -      "Network.Socket.Types.peekSockAddr: address family '" ++
 -      show family ++ "' not supported."
--
--------------------------------------------------------------------------
--
---- | The raw network byte order number is read using host byte order.
---- Therefore on little-endian architectures the byte order is swapped. For
---- example @127.0.0.1@ is represented as @0x0100007f@ on little-endian hosts
---- and as @0x7f000001@ on big-endian hosts.
----
---- For direct manipulation prefer 'hostAddressToTuple' and
---- 'tupleToHostAddress'.
--type HostAddress = Word32
--
---- | Converts 'HostAddress' to representation-independent IPv4 quadruple.
---- For example for @127.0.0.1@ the function will return @(0x7f, 0, 0, 1)@
---- regardless of host endianness.
--hostAddressToTuple :: HostAddress -> (Word8, Word8, Word8, Word8)
--hostAddressToTuple ha' =
++-- | Use a 'SockAddr' with a function requiring a pointer to a
++-- 'SockAddr' and the length of that 'SockAddr'.
++withSockAddr :: SockAddr -> (SocketAddress -> IO a) -> IO a
++withSockAddr addr f = case addr of
++  SockAddrInet port host ->
++    f $ superCast $ mkInetSocketAddress
++      (getByAddress . toJByteArray $ padWord8s 4 host)
++      (fromIntegral port)
++  SockAddrInet6 port _ (w1, w2, w3, w4) _ ->
++    f $ superCast $ mkInetSocketAddress
++      (getByAddress . toJByteArray $ concatMap (padWord8s 4) [w1, w2, w3, w4])
++      (fromIntegral port)
++  _ -> error "Network.Socket.Types.withSockAddr: Invalid socket address type."
++  where toWord8s :: (Bits a, Integral a) => a -> [Word8]
++        toWord8s 0 = []
++        toWord8s n = fromIntegral (n .&. 255) : toWord8s (n `shiftR` 8)
++
++        padWord8s :: (Bits a, Integral a) => Int -> a -> [Word8]
++        padWord8s n a = replicate (abs (n - length word8s)) 0 ++ word8s
++          where word8s = reverse (toWord8s a)
+ 
+ ------------------------------------------------------------------------
+ 
+@@ -1016,7 +899,7 @@ type HostAddress = Word32
+ -- regardless of host endianness.
+ hostAddressToTuple :: HostAddress -> (Word8, Word8, Word8, Word8)
+ hostAddressToTuple ha' =
 -    let ha = htonl ha'
--        byte i = fromIntegral (ha `shiftR` i) :: Word8
--    in (byte 24, byte 16, byte 8, byte 0)
--
---- | Converts IPv4 quadruple to 'HostAddress'.
--tupleToHostAddress :: (Word8, Word8, Word8, Word8) -> HostAddress
--tupleToHostAddress (b3, b2, b1, b0) =
--    let x `sl` i = fromIntegral x `shiftL` i :: Word32
++    let ha = ha'
+         byte i = fromIntegral (ha `shiftR` i) :: Word8
+     in (byte 24, byte 16, byte 8, byte 0)
+ 
+@@ -1024,7 +907,7 @@ hostAddressToTuple ha' =
+ tupleToHostAddress :: (Word8, Word8, Word8, Word8) -> HostAddress
+ tupleToHostAddress (b3, b2, b1, b0) =
+     let x `sl` i = fromIntegral x `shiftL` i :: Word32
 -    in ntohl $ (b3 `sl` 24) .|. (b2 `sl` 16) .|. (b1 `sl` 8) .|. (b0 `sl` 0)
--
--#if defined(IPV6_SOCKET_SUPPORT)
---- | Independent of endianness. For example @::1@ is stored as @(0, 0, 0, 1)@.
----
---- For direct manipulation prefer 'hostAddress6ToTuple' and
---- 'tupleToHostAddress6'.
--type HostAddress6 = (Word32, Word32, Word32, Word32)
--
--hostAddress6ToTuple :: HostAddress6 -> (Word16, Word16, Word16, Word16,
--                                        Word16, Word16, Word16, Word16)
--hostAddress6ToTuple (w3, w2, w1, w0) =
--    let high, low :: Word32 -> Word16
--        high w = fromIntegral (w `shiftR` 16)
--        low w = fromIntegral w
--    in (high w3, low w3, high w2, low w2, high w1, low w1, high w0, low w0)
--
--tupleToHostAddress6 :: (Word16, Word16, Word16, Word16,
--                        Word16, Word16, Word16, Word16) -> HostAddress6
--tupleToHostAddress6 (w7, w6, w5, w4, w3, w2, w1, w0) =
--    let add :: Word16 -> Word16 -> Word32
--        high `add` low = (fromIntegral high `shiftL` 16) .|. (fromIntegral low)
--    in (w7 `add` w6, w5 `add` w4, w3 `add` w2, w1 `add` w0)
++    in (b3 `sl` 24) .|. (b2 `sl` 16) .|. (b1 `sl` 8) .|. (b0 `sl` 0)
+ 
+ #if defined(IPV6_SOCKET_SUPPORT)
+ -- | Independent of endianness. For example @::1@ is stored as @(0, 0, 0, 1)@.
+@@ -1047,65 +930,72 @@ tupleToHostAddress6 (w7, w6, w5, w4, w3, w2, w1, w0) =
+     let add :: Word16 -> Word16 -> Word32
+         high `add` low = (fromIntegral high `shiftL` 16) .|. (fromIntegral low)
+     in (w7 `add` w6, w5 `add` w4, w3 `add` w2, w1 `add` w0)
 -
 --- The peek32 and poke32 functions work around the fact that the RFCs
 --- don't require 32-bit-wide address fields to be present.  We can
@@ -7679,16 +2181,79 @@ index bed07d1..0000000
 -        poke32 p 1 b
 -        poke32 p 2 c
 -        poke32 p 3 d
--#endif
--
+ #endif
+ 
 -------------------------------------------------------------------------
 --- Helper functions
--
++-- ------------------------------------------------------------------------
++-- -- Helper functions
++
+ 
 -foreign import ccall unsafe "string.h" memset :: Ptr a -> CInt -> CSize -> IO ()
--
---- | Zero a structure.
--zeroMemory :: Ptr a -> CSize -> IO ()
++foreign import java unsafe "@static eta.base.Utils.c_memset" memset
++  :: Ptr a -> CInt -> CSize -> IO (Ptr a)
+ 
+ -- | Zero a structure.
+ zeroMemory :: Ptr a -> CSize -> IO ()
 -zeroMemory dest nbytes = memset dest 0 (fromIntegral nbytes)
++zeroMemory dest nbytes = memset dest 0 (fromIntegral nbytes) >> return ()
++
++data {-# CLASS "java.net.SocketAddress" #-} SocketAddress =
++  SA (Object# SocketAddress)
++  deriving Class
++
++type instance Inherits SocketAddress = '[Object]
++
++data {-# CLASS "java.net.InetSocketAddress" #-} InetSocketAddress =
++  ISA (Object# InetSocketAddress)
++  deriving Class
++
++type instance Inherits InetSocketAddress = '[SocketAddress]
++
++data {-# CLASS "java.net.InetAddress" #-} InetAddress =
++  IA (Object# InetAddress)
++  deriving Class
++
++type instance Inherits InetAddress = '[Object]
++
++data {-# CLASS "java.net.InetAddress[]" #-} InetAddressArray =
++  IArr (Object# InetAddressArray)
++  deriving Class
++
++instance JArray InetAddress InetAddressArray
++
++data {-# CLASS "java.net.Inet4Address" #-} Inet4Address =
++  I4A (Object# Inet4Address)
++  deriving Class
++
++type instance Inherits Inet4Address = '[InetAddress]
++
++data {-# CLASS "java.net.Inet6Address" #-} Inet6Address =
++  I6A (Object# Inet6Address)
++  deriving Class
++
++type instance Inherits Inet6Address = '[InetAddress]
++
++foreign import java unsafe "@static java.net.InetAddress.getByAddress" getByAddress :: JByteArray -> InetAddress
++
++foreign import java unsafe "@new" mkInetSocketAddress
++  :: InetAddress -> Int -> InetSocketAddress
++
++foreign import java unsafe "@static eta.network.Utils.getSockAddr" getSockAddr
++  :: Channel -> IO InetSocketAddress
++
++foreign import java unsafe "getAddress" sockInetAddress
++  :: InetSocketAddress -> InetAddress
++
++foreign import CALLCONV unsafe "getPort" sockPort :: InetSocketAddress -> Int
++
++toJByteArray :: [Word8] -> JByteArray
++toJByteArray word8s = toJava bytes
++  where bytes = map fromIntegral word8s :: [Byte]
++
++foreign import CALLCONV unsafe "@static eta.network.Utils.inetAddrInt"
++  inetAddrInt :: InetAddress -> Word32
++
 diff --git a/include/HsNet.h b/include/HsNet.h
 index 858ce4e..c172e11 100644
 --- a/include/HsNet.h
@@ -8244,10 +2809,10 @@ index 6dcef8f..0000000
 -/* #undef const */
 diff --git a/java/Utils.java b/java/Utils.java
 new file mode 100644
-index 0000000..fa4a9b0
+index 0000000..9229860
 --- /dev/null
 +++ b/java/Utils.java
-@@ -0,0 +1,192 @@
+@@ -0,0 +1,193 @@
 +package eta.network;
 +
 +import java.io.IOException;
@@ -8374,6 +2939,7 @@ index 0000000..fa4a9b0
 +    }
 +
 +    public static Channel accept(Channel c) throws IOException {
++        Thread.interrupted();
 +        if (c instanceof ServerSocketChannel) {
 +            return ((ServerSocketChannel) c).accept();
 +        } else {
@@ -8495,5 +3061,5 @@ index ede8fd2..0350a44 100644
  test-suite simple
    hs-source-dirs: tests
 -- 
-2.7.4 (Apple Git-66)
+2.18.0
 


### PR DESCRIPTION
Add `Thread.interrupted()` in the beginning of 'accept()' to clear interrupted status, so `ClosedByInterruptException` won't be accidentally raised.