### PR TITLE
Patched megaparsec-7.0.3

### DIFF
--- a/patches/megaparsec-7.0.3.cabal
+++ b/patches/megaparsec-7.0.3.cabal
@@ -1,0 +1,160 @@
+name:                 megaparsec
+version:              7.0.3
+cabal-version:        1.18
+tested-with:          GHC==7.10.3, GHC==8.0.2, GHC==8.2.2, GHC==8.4.4, GHC==8.6.1
+license:              BSD2
+license-file:         LICENSE.md
+author:               Megaparsec contributors,
+                      Paolo Martini <paolo@nemail.it>,
+                      Daan Leijen <daan@microsoft.com>
+
+maintainer:           Mark Karpov <markkarpov92@gmail.com>
+homepage:             https://github.com/mrkkrp/megaparsec
+bug-reports:          https://github.com/mrkkrp/megaparsec/issues
+category:             Parsing
+synopsis:             Monadic parser combinators
+build-type:           Simple
+description:
+
+  This is an industrial-strength monadic parser combinator library.
+  Megaparsec is a feature-rich package that strikes a nice balance between
+  speed, flexibility, and quality of parse errors.
+
+extra-doc-files:      AUTHORS.md
+                    , CHANGELOG.md
+                    , README.md
+
+source-repository head
+  type:               git
+  location:           https://github.com/mrkkrp/megaparsec.git
+
+flag dev
+  description:        Turn on development settings.
+  manual:             True
+  default:            False
+
+library
+  build-depends:      base         >= 4.8   && < 5.0
+                    , bytestring   >= 0.2   && < 0.11
+                    , case-insensitive >= 1.2 && < 1.3
+                    , containers   >= 0.5   && < 0.7
+                    , deepseq      >= 1.3   && < 1.5
+                    , mtl          >= 2.0   && < 3.0
+                    , parser-combinators >= 1.0 && < 2.0
+                    , scientific   >= 0.3.1 && < 0.4
+                    , text         >= 0.2   && < 1.3
+                    , transformers >= 0.4   && < 0.6
+  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+    build-depends:    fail         == 4.9.*
+                    , semigroups   == 0.18.*
+  if !impl(ghc >= 7.10)
+    build-depends:    void         == 0.7.*
+  exposed-modules:    Text.Megaparsec
+                    , Text.Megaparsec.Byte
+                    , Text.Megaparsec.Byte.Lexer
+                    , Text.Megaparsec.Char
+                    , Text.Megaparsec.Char.Lexer
+                    , Text.Megaparsec.Debug
+                    , Text.Megaparsec.Error
+                    , Text.Megaparsec.Error.Builder
+                    , Text.Megaparsec.Internal
+                    , Text.Megaparsec.Pos
+                    , Text.Megaparsec.Stream
+  other-modules:      Text.Megaparsec.Class
+                    , Text.Megaparsec.Common
+                    , Text.Megaparsec.Lexer
+                    , Text.Megaparsec.State
+  
+  if flag(dev)
+    ghc-options:      -O0 -Wall -Werror
+  else
+    ghc-options:      -O2 -Wall
+  if flag(dev) && impl(ghc >= 8.0)
+    ghc-options:      -Wcompat
+                      -Wincomplete-record-updates
+                      -Wincomplete-uni-patterns
+                      -Wnoncanonical-monad-instances
+                      -Wnoncanonical-monadfail-instances
+  default-language:   Haskell2010
+
+test-suite tests
+  main-is:            Main.hs
+  hs-source-dirs:     tests
+  type:               exitcode-stdio-1.0
+  if flag(dev)
+    ghc-options:      -O0 -Wall -Werror
+  else
+    ghc-options:      -O2 -Wall
+  other-modules:      Control.Applicative.CombinatorsSpec
+                    , Control.Applicative.PermutationsSpec
+                    , Control.Monad.Combinators.ExprSpec
+                    , Control.Monad.CombinatorsSpec
+                    , Test.Hspec.Megaparsec
+                    , Test.Hspec.Megaparsec.AdHoc
+                    , Text.Megaparsec.Byte.LexerSpec
+                    , Text.Megaparsec.ByteSpec
+                    , Text.Megaparsec.Char.LexerSpec
+                    , Text.Megaparsec.CharSpec
+                    , Text.Megaparsec.DebugSpec
+                    , Text.Megaparsec.ErrorSpec
+                    , Text.Megaparsec.PosSpec
+                    , Text.Megaparsec.StreamSpec
+                    , Text.MegaparsecSpec
+  build-depends:      QuickCheck   >= 2.7   && < 2.13
+                    , base         >= 4.8   && < 5.0
+                    , bytestring   >= 0.2   && < 0.11
+                    , case-insensitive >= 1.2 && < 1.3
+                    , containers   >= 0.5   && < 0.7
+                    , hspec        >= 2.0   && < 3.0
+                    , hspec-expectations >= 0.8 && < 0.9
+                    , megaparsec
+                    , mtl          >= 2.0   && < 3.0
+                    , parser-combinators >= 1.0 && < 2.0
+                    , scientific   >= 0.3.1 && < 0.4
+                    , text         >= 0.2   && < 1.3
+                    , transformers >= 0.4   && < 0.6
+  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+    build-depends:    semigroups   == 0.18.*
+  if !impl(ghc >= 7.10)
+    build-depends:    void         == 0.7.*
+  default-language:   Haskell2010
+
+benchmark bench-speed
+  main-is:            Main.hs
+  hs-source-dirs:     bench/speed
+  type:               exitcode-stdio-1.0
+  build-depends:      base         >= 4.8  && < 5.0
+                    , containers   >= 0.5  && < 0.7
+                    , criterion    >= 0.6.2.1 && < 1.6
+                    , deepseq      >= 1.3  && < 1.5
+                    , megaparsec
+                    , text         >= 0.2  && < 1.3
+  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+    build-depends:    semigroups   == 0.18.*
+  if !impl(ghc >= 7.10)
+    build-depends:    void         == 0.7.*
+  if flag(dev)
+    ghc-options:      -O2 -Wall -Werror
+  else
+    ghc-options:      -O2 -Wall
+  default-language:   Haskell2010
+
+benchmark bench-memory
+  main-is:            Main.hs
+  hs-source-dirs:     bench/memory
+  type:               exitcode-stdio-1.0
+  build-depends:      base         >= 4.8  && < 5.0
+                    , containers   >= 0.5  && < 0.7
+                    , deepseq      >= 1.3  && < 1.5
+                    , megaparsec
+                    , text         >= 0.2  && < 1.3
+                    , weigh        >= 0.0.4
+  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+    build-depends:    semigroups   == 0.18.*
+  if !impl(ghc >= 7.10)
+    build-depends:    void         == 0.7.*
+  if flag(dev)
+    ghc-options:      -O2 -Wall -Werror
+  else
+    ghc-options:      -O2 -Wall
+  default-language:   Haskell2010

--- a/patches/megaparsec-7.0.3.patch
+++ b/patches/megaparsec-7.0.3.patch
@@ -1,0 +1,82 @@
+From f37175b58cccc5674bb25eeca9faad6f1d2ad26a Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Sat, 3 Nov 2018 01:16:23 +0100
+Subject: [PATCH] Patched
+
+---
+ Text/Megaparsec/Internal.hs | 3 ++-
+ megaparsec.cabal            | 9 +++++----
+ 2 files changed, 7 insertions(+), 5 deletions(-)
+
+diff --git a/Text/Megaparsec/Internal.hs b/Text/Megaparsec/Internal.hs
+index 89ac159..61bc2ab 100644
+--- a/Text/Megaparsec/Internal.hs
++++ b/Text/Megaparsec/Internal.hs
+@@ -54,6 +54,7 @@ import Control.Monad.IO.Class
+ import Control.Monad.Reader.Class
+ import Control.Monad.State.Class
+ import Control.Monad.Trans
++import Data.Function (trampoline)
+ import Data.List.NonEmpty (NonEmpty (..))
+ import Data.Proxy
+ import Data.Semigroup
+@@ -603,7 +604,7 @@ runParsecT :: Monad m
+   => ParsecT e s m a -- ^ Parser to run
+   -> State s       -- ^ Initial state
+   -> m (Reply e s a)
+-runParsecT p s = unParser p s cok cerr eok eerr
++runParsecT p s = trampoline $ unParser p s cok cerr eok eerr
+   where
+     cok a s' _  = return $ Reply s' Consumed (OK a)
+     cerr err s' = return $ Reply s' Consumed (Error err)
+diff --git a/megaparsec.cabal b/megaparsec.cabal
+index 5145c07..e555e31 100644
+--- a/megaparsec.cabal
++++ b/megaparsec.cabal
+@@ -44,7 +44,7 @@ library
+                     , scientific   >= 0.3.1 && < 0.4
+                     , text         >= 0.2   && < 1.3
+                     , transformers >= 0.4   && < 0.6
+-  if !impl(ghc >= 8.0)
++  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+     build-depends:    fail         == 4.9.*
+                     , semigroups   == 0.18.*
+   if !impl(ghc >= 7.10)
+@@ -64,6 +64,7 @@ library
+                     , Text.Megaparsec.Common
+                     , Text.Megaparsec.Lexer
+                     , Text.Megaparsec.State
++  
+   if flag(dev)
+     ghc-options:      -O0 -Wall -Werror
+   else
+@@ -112,7 +113,7 @@ test-suite tests
+                     , scientific   >= 0.3.1 && < 0.4
+                     , text         >= 0.2   && < 1.3
+                     , transformers >= 0.4   && < 0.6
+-  if !impl(ghc >= 8.0)
++  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+     build-depends:    semigroups   == 0.18.*
+   if !impl(ghc >= 7.10)
+     build-depends:    void         == 0.7.*
+@@ -128,7 +129,7 @@ benchmark bench-speed
+                     , deepseq      >= 1.3  && < 1.5
+                     , megaparsec
+                     , text         >= 0.2  && < 1.3
+-  if !impl(ghc >= 8.0)
++  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+     build-depends:    semigroups   == 0.18.*
+   if !impl(ghc >= 7.10)
+     build-depends:    void         == 0.7.*
+@@ -148,7 +149,7 @@ benchmark bench-memory
+                     , megaparsec
+                     , text         >= 0.2  && < 1.3
+                     , weigh        >= 0.0.4
+-  if !impl(ghc >= 8.0)
++  if !impl(ghc >= 8.0) && !impl(eta >= 0.8.4)
+     build-depends:    semigroups   == 0.18.*
+   if !impl(ghc >= 7.10)
+     build-depends:    void         == 0.7.*
+-- 
+2.16.2.windows.1
+


### PR DESCRIPTION
* New version 7.0.x or/and its use in dhall-1.18.0 throws fewer StackOverflow's but still it throws some
* No support for eta version <= 0.0.9.7, let me know if you think it is still needed
* Not sure if it is needed to replicate the patch for 7.0.0/1/2