### PR TITLE
Patch dhall-1.19.1 with createDirectoryIfMissing

### DIFF
--- a/patches/dhall-1.19.1.patch
+++ b/patches/dhall-1.19.1.patch
@@ -1,11 +1,12 @@
-From 101d5140bc3242a154d98cc8f5a7ba8c0d419ed9 Mon Sep 17 00:00:00 2001
+From 888bd5d4aad105945b18be10d1e91da914d9bcd7 Mon Sep 17 00:00:00 2001
 From: jneira <atreyu.bbb@gmail.com>
-Date: Fri, 7 Dec 2018 21:54:06 +0100
+Date: Wed, 12 Dec 2018 09:46:27 +0100
 Subject: [PATCH] Patched
 
 ---
- dhall.cabal | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
+ dhall.cabal         | 2 +-
+ src/Dhall/Import.hs | 4 ++--
+ 2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/dhall.cabal b/dhall.cabal
 index 5522e56..59eace3 100644
@@ -20,6 +21,21 @@ index 5522e56..59eace3 100644
        Build-Depends: semigroups == 0.18.*
        Build-Depends: transformers == 0.4.2.*
        Build-Depends: fail == 4.9.*
+diff --git a/src/Dhall/Import.hs b/src/Dhall/Import.hs
+index 972fbb3..e08363b 100644
+--- a/src/Dhall/Import.hs
++++ b/src/Dhall/Import.hs
+@@ -561,8 +561,8 @@ getCacheFile hash = do
+ 
+                 else do
+                     assertDirectory (FilePath.takeDirectory directory)
+-
+-                    liftIO (Directory.createDirectory directory)
++                    -- Double checking to handle a possible IO error in doesDirectoryExist
++                    liftIO (Directory.createDirectoryIfMissing False directory)
+ 
+                     liftIO (Directory.setPermissions directory private)
+ 
 -- 
 2.16.2.windows.1
 


### PR DESCRIPTION
Hi, i am getting an strange error in a circleci eta docker env:
```
 Exception: user error (The import failed but it had to success. Dhall exception: 
        ↳ ./../dhall-lang/tests/import/success/issue553A.dhall sha256:e2d014696fb7d773727ae5aa42dc20bbd2447ea82bcb5971ccbb7763906edace
        JException java.nio.file.FileAlreadyExistsException: /root/.cache)
```
The [code being executed](https://github.com/dhall-lang/dhall-haskell/blob/master/dhall/src/Dhall/Import.hs#L558-L571) is:
```haskell
directoryExists <- liftIO (Directory.doesDirectoryExist directory)

if directoryExists
   then do
      permissions <- liftIO (Directory.getPermissions directory)

      guard (accessible permissions)

   else do
      assertDirectory (FilePath.takeDirectory directory)

      liftIO (Directory.createDirectory directory)

      liftIO (Directory.setPermissions directory private)
```
As it only tries to create the directory when it doesnt exist i guess `Directory.doesDirectoryExist` is not working correctly.
It calls in turn to [Files.isDirectory](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html#isDirectory(java.nio.file.Path,%20java.nio.file.LinkOption...)) which javadoc states:
```
Tests whether a file is a directory.
The options array may be used to indicate how symbolic links are handled for the case that the file is a symbolic link. By default, symbolic links are followed and the file attribute of the final target of the link is read. If the option NOFOLLOW_LINKS is present then symbolic links are not followed.

Where is it required to distinguish an I/O exception from the case that the file is not a directory then the file attributes can be read with the readAttributes method and the file type tested with the BasicFileAttributes.isDirectory() method.
```
It behaves identically to `Directory.doesDirectoryExist` so dhall itself should fail in circleci as well: it seems in that env `Directory.doesDirectoryExist` returns false due a IOException (and not cause it really doesnt exist). No time to test it so let's see first if the patch works for etlas and then we can try to apply upstream.