### PR TITLE
Patching Duckling

### DIFF
--- a/patches/aeson-0.11.3.0.patch
+++ b/patches/aeson-0.11.3.0.patch
@@ -1,13 +1,27 @@
-From f192a8243b1cd864e3a728b77d649b28a6849293 Mon Sep 17 00:00:00 2001
-From: Rahul Muttineni <rahulmutt@gmail.com>
-Date: Fri, 23 Mar 2018 12:38:36 +0530
+From b4b06d2c26428d707c90ab5f70f0ced4f1b08d88 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 13:08:37 +0200
 Subject: [PATCH] Patched
 
 ---
+ Data/Aeson/Types/Generic.hs  |  2 +-
  Data/Aeson/Types/Internal.hs | 26 +++++++++++++-------------
  aeson.cabal                  |  2 +-
- 2 files changed, 14 insertions(+), 14 deletions(-)
+ 3 files changed, 15 insertions(+), 15 deletions(-)
 
+diff --git a/Data/Aeson/Types/Generic.hs b/Data/Aeson/Types/Generic.hs
+index 2bf389f..7e7d5d5 100644
+--- a/Data/Aeson/Types/Generic.hs
++++ b/Data/Aeson/Types/Generic.hs
+@@ -738,7 +738,7 @@ class IsRecord (f :: * -> *) isRecord | f -> isRecord
+ 
+ instance (IsRecord f isRecord) => IsRecord (f :*: g) isRecord
+   where isUnary = const False
+-#if MIN_VERSION_base(4,9,0)
++#if MIN_VERSION_base(4,9,0) && !defined(TOOL_VERSION_eta)
+ instance OVERLAPPING_ IsRecord (M1 S ('MetaSel 'Nothing u ss ds) f) False
+ #else
+ instance OVERLAPPING_ IsRecord (M1 S NoSelector f) False
 diff --git a/Data/Aeson/Types/Internal.hs b/Data/Aeson/Types/Internal.hs
 index 2d88035..7fd1688 100644
 --- a/Data/Aeson/Types/Internal.hs
@@ -59,5 +73,5 @@ index 4b6e6ef..d02ddaa 100644
    other-modules:
      Data.Aeson.Encode.Builder
 -- 
-2.7.4 (Apple Git-66)
+2.16.2.windows.1
 

--- a/patches/base-compat-batteries-0.10.1.cabal
+++ b/patches/base-compat-batteries-0.10.1.cabal
@@ -1,0 +1,228 @@
+name:             base-compat-batteries
+version:          0.10.1
+license:          MIT
+license-file:     LICENSE
+copyright:        (c) 2012-2018 Simon Hengel,
+                  (c) 2014-2018 João Cristóvão,
+                  (c) 2015-2018 Ryan Scott
+author:           Simon Hengel <sol@typeful.net>,
+                  João Cristóvão <jmacristovao@gmail.com>,
+                  Ryan Scott <ryan.gl.scott@gmail.com>
+maintainer:       Simon Hengel <sol@typeful.net>,
+                  João Cristóvão <jmacristovao@gmail.com>,
+                  Ryan Scott <ryan.gl.scott@gmail.com>
+build-type:       Simple
+cabal-version:    >= 1.8
+category:         Compatibility
+synopsis:         base-compat with extra batteries
+description:      Provides functions available in later versions of @base@ to
+                  a wider range of compilers, without requiring you to use CPP
+                  pragmas in your code.
+                  .
+                  This package provides the same API as the
+                  @<http://hackage.haskell.org/package/base-compat base-compat>@
+                  library, but depends on compatibility packages
+                  (such as @semigroups@) to offer a wider support window than
+                  @base-compat@, which has no dependencies. Most of the modules
+                  in this library have the same names as in @base-compat@
+                  to make it easier to switch between the two. There also exist
+                  versions of each module with the suffix @.Repl.Batteries@,
+                  which are distinct from anything in @base-compat@, to allow
+                  for easier use in GHCi.
+                  .
+                  See
+                  @<https://github.com/haskell-compat/base-compat/blob/master/base-compat/README.markdown#dependencies here>@
+                  for a more comprehensive list of differences between
+                  @base-compat@ and @base-compat-batteries@.
+tested-with:        GHC == 7.0.1,  GHC == 7.0.2,  GHC == 7.0.3,  GHC == 7.0.4
+                  , GHC == 7.2.1,  GHC == 7.2.2
+                  , GHC == 7.4.1,  GHC == 7.4.2
+                  , GHC == 7.6.1,  GHC == 7.6.2,  GHC == 7.6.3
+                  , GHC == 7.8.1,  GHC == 7.8.2,  GHC == 7.8.3,  GHC == 7.8.4
+                  , GHC == 7.10.1, GHC == 7.10.2, GHC == 7.10.3
+                  , GHC == 8.0.1,  GHC == 8.0.2
+                  , GHC == 8.2.1,  GHC == 8.2.2
+                  , GHC == 8.4.1
+extra-source-files: CHANGES.markdown, README.markdown
+
+source-repository head
+  type: git
+  location: https://github.com/haskell-compat/base-compat
+  subdir: base-compat-batteries
+
+library
+  ghc-options:
+      -Wall
+  build-depends:
+      base        >= 4.3    && < 5,
+      base-compat >= 0.10.1 && < 0.11
+  if !impl(ghc >= 7.8)
+    build-depends:
+      tagged >= 0.8.5 && < 0.9
+  if !impl(ghc >= 7.10)
+    build-depends:
+      nats >= 1.1.2 && < 1.2,
+      void >= 0.7.2 && < 0.8
+  if !impl(ghc >= 8.0)
+    build-depends:
+      fail                >= 4.9.0.0 && < 4.10,
+      semigroups          >= 0.18.4  && < 0.19,
+      transformers        >= 0.2     && < 0.6,
+      transformers-compat >= 0.6     && < 0.7
+  if !impl(ghc >= 8.2)
+    build-depends:
+      bifunctors >= 5.5.2 && < 5.6
+  ghc-options:
+      -fno-warn-duplicate-exports
+
+  hs-source-dirs:
+      src
+
+  exposed-modules:
+      Control.Concurrent.Compat
+      Control.Concurrent.MVar.Compat
+      Control.Monad.Compat
+      Control.Monad.Fail.Compat
+      Control.Monad.IO.Class.Compat
+      Control.Monad.ST.Lazy.Unsafe.Compat
+      Control.Monad.ST.Unsafe.Compat
+      Data.Bifoldable.Compat
+      Data.Bifunctor.Compat
+      Data.Bitraversable.Compat
+      Data.Bits.Compat
+      Data.Bool.Compat
+      Data.Complex.Compat
+      Data.Either.Compat
+      Data.Foldable.Compat
+      Data.Function.Compat
+      Data.Functor.Compat
+      Data.Functor.Compose.Compat
+      Data.Functor.Const.Compat
+      Data.Functor.Identity.Compat
+      Data.Functor.Product.Compat
+      Data.Functor.Sum.Compat
+      Data.IORef.Compat
+      Data.List.Compat
+      Data.List.NonEmpty.Compat
+      Data.Monoid.Compat
+      Data.Proxy.Compat
+      Data.Ratio.Compat
+      Data.Semigroup.Compat
+      Data.STRef.Compat
+      Data.String.Compat
+      Data.Type.Coercion.Compat
+      Data.Version.Compat
+      Data.Void.Compat
+      Data.Word.Compat
+      Debug.Trace.Compat
+      Foreign.Compat
+      Foreign.ForeignPtr.Compat
+      Foreign.ForeignPtr.Safe.Compat
+      Foreign.ForeignPtr.Unsafe.Compat
+      Foreign.Marshal.Alloc.Compat
+      Foreign.Marshal.Array.Compat
+      Foreign.Marshal.Compat
+      Foreign.Marshal.Safe.Compat
+      Foreign.Marshal.Unsafe.Compat
+      Foreign.Marshal.Utils.Compat
+      Numeric.Compat
+      Numeric.Natural.Compat
+      Prelude.Compat
+      System.Environment.Compat
+      System.Exit.Compat
+      System.IO.Unsafe.Compat
+      Text.Read.Compat
+
+      Control.Concurrent.Compat.Repl.Batteries
+      Control.Concurrent.MVar.Compat.Repl.Batteries
+      Control.Monad.Compat.Repl.Batteries
+      Control.Monad.Fail.Compat.Repl.Batteries
+      Control.Monad.IO.Class.Compat.Repl.Batteries
+      Control.Monad.ST.Lazy.Unsafe.Compat.Repl.Batteries
+      Control.Monad.ST.Unsafe.Compat.Repl.Batteries
+      Data.Bifoldable.Compat.Repl.Batteries
+      Data.Bifunctor.Compat.Repl.Batteries
+      Data.Bitraversable.Compat.Repl.Batteries
+      Data.Bits.Compat.Repl.Batteries
+      Data.Bool.Compat.Repl.Batteries
+      Data.Complex.Compat.Repl.Batteries
+      Data.Either.Compat.Repl.Batteries
+      Data.Foldable.Compat.Repl.Batteries
+      Data.Function.Compat.Repl.Batteries
+      Data.Functor.Compat.Repl.Batteries
+      Data.Functor.Compose.Compat.Repl.Batteries
+      Data.Functor.Const.Compat.Repl.Batteries
+      Data.Functor.Identity.Compat.Repl.Batteries
+      Data.Functor.Product.Compat.Repl.Batteries
+      Data.Functor.Sum.Compat.Repl.Batteries
+      Data.IORef.Compat.Repl.Batteries
+      Data.List.Compat.Repl.Batteries
+      Data.List.NonEmpty.Compat.Repl.Batteries
+      Data.Monoid.Compat.Repl.Batteries
+      Data.Proxy.Compat.Repl.Batteries
+      Data.Ratio.Compat.Repl.Batteries
+      Data.Semigroup.Compat.Repl.Batteries
+      Data.STRef.Compat.Repl.Batteries
+      Data.String.Compat.Repl.Batteries
+      Data.Type.Coercion.Compat.Repl.Batteries
+      Data.Version.Compat.Repl.Batteries
+      Data.Void.Compat.Repl.Batteries
+      Data.Word.Compat.Repl.Batteries
+      Debug.Trace.Compat.Repl.Batteries
+      Foreign.Compat.Repl.Batteries
+      Foreign.ForeignPtr.Compat.Repl.Batteries
+      Foreign.ForeignPtr.Safe.Compat.Repl.Batteries
+      Foreign.ForeignPtr.Unsafe.Compat.Repl.Batteries
+      Foreign.Marshal.Alloc.Compat.Repl.Batteries
+      Foreign.Marshal.Array.Compat.Repl.Batteries
+      Foreign.Marshal.Compat.Repl.Batteries
+      Foreign.Marshal.Safe.Compat.Repl.Batteries
+      Foreign.Marshal.Unsafe.Compat.Repl.Batteries
+      Foreign.Marshal.Utils.Compat.Repl.Batteries
+      Numeric.Compat.Repl.Batteries
+      Numeric.Natural.Compat.Repl.Batteries
+      Prelude.Compat.Repl.Batteries
+      System.Environment.Compat.Repl.Batteries
+      System.Exit.Compat.Repl.Batteries
+      System.IO.Unsafe.Compat.Repl.Batteries
+      Text.Read.Compat.Repl.Batteries
+  if !impl(eta)
+      exposed-modules:
+        Type.Reflection.Compat
+        Type.Reflection.Compat.Repl.Batteries
+
+test-suite spec
+  type:
+      exitcode-stdio-1.0
+  ghc-options:
+      -Wall
+  hs-source-dirs:
+      test
+  main-is:
+      Spec.hs
+  other-modules:
+      Control.Monad.CompatSpec
+      Data.Bits.CompatSpec
+      Data.Bool.CompatSpec
+      Data.Either.CompatSpec
+      Data.Foldable.CompatSpec
+      Data.Function.CompatSpec
+      Data.Functor.CompatSpec
+      Data.IORef.CompatSpec
+      Data.List.CompatSpec
+      Data.Monoid.CompatSpec
+      Data.STRef.CompatSpec
+      Data.Version.CompatSpec
+      Data.Word.CompatSpec
+      Foreign.Marshal.Alloc.CompatSpec
+      Foreign.Marshal.Utils.CompatSpec
+      Numeric.CompatSpec
+      System.Environment.CompatSpec
+      Text.Read.CompatSpec
+  build-depends:
+      base >= 4.3 && < 5
+    , base-compat-batteries
+    , hspec >= 1.8
+    , QuickCheck
+  build-tool-depends:
+      hspec-discover:hspec-discover >= 1.8

--- a/patches/base-compat-batteries-0.10.1.patch
+++ b/patches/base-compat-batteries-0.10.1.patch
@@ -1,0 +1,37 @@
+From da11cd7a4579eaee67557040a673a927bcf6f453 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 10:27:10 +0200
+Subject: [PATCH] Patched
+
+---
+ base-compat-batteries.cabal | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/base-compat-batteries.cabal b/base-compat-batteries.cabal
+index d127a17..dca0fef 100644
+--- a/base-compat-batteries.cabal
++++ b/base-compat-batteries.cabal
+@@ -132,7 +132,6 @@ library
+       System.Exit.Compat
+       System.IO.Unsafe.Compat
+       Text.Read.Compat
+-      Type.Reflection.Compat
+ 
+       Control.Concurrent.Compat.Repl.Batteries
+       Control.Concurrent.MVar.Compat.Repl.Batteries
+@@ -187,7 +186,11 @@ library
+       System.Exit.Compat.Repl.Batteries
+       System.IO.Unsafe.Compat.Repl.Batteries
+       Text.Read.Compat.Repl.Batteries
+-      Type.Reflection.Compat.Repl.Batteries
++  if !impl(eta)
++      exposed-modules:
++        Type.Reflection.Compat
++        Type.Reflection.Compat.Repl.Batteries
++
+ test-suite spec
+   type:
+       exitcode-stdio-1.0
+-- 
+2.16.2.windows.1
+

--- a/patches/bifunctors-5.5.4.cabal
+++ b/patches/bifunctors-5.5.4.cabal
@@ -1,0 +1,118 @@
+name:          bifunctors
+category:      Data, Functors
+version:       5.5.4
+license:       BSD3
+cabal-version: >= 1.8
+license-file:  LICENSE
+author:        Edward A. Kmett
+maintainer:    Edward A. Kmett <ekmett@gmail.com>
+stability:     provisional
+homepage:      http://github.com/ekmett/bifunctors/
+bug-reports:   http://github.com/ekmett/bifunctors/issues
+copyright:     Copyright (C) 2008-2016 Edward A. Kmett
+synopsis:      Bifunctors
+description:   Bifunctors.
+build-type:    Simple
+tested-with:   GHC == 7.0.4
+             , GHC == 7.2.2
+             , GHC == 7.4.2
+             , GHC == 7.6.3
+             , GHC == 7.8.4
+             , GHC == 7.10.3
+             , GHC == 8.0.2
+             , GHC == 8.2.2
+             , GHC == 8.4.4
+             , GHC == 8.6.4
+extra-source-files: .travis.yml CHANGELOG.markdown README.markdown
+
+source-repository head
+  type: git
+  location: https://github.com/ekmett/bifunctors.git
+
+flag semigroups
+  default: True
+  manual: True
+  description:
+    You can disable the use of the `semigroups` package using `-f-semigroups`.
+    .
+    Disabing this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+
+flag tagged
+  default: True
+  manual: True
+  description:
+    You can disable the use of the `tagged` package using `-f-tagged`.
+    .
+    Disabing this is an unsupported configuration, but it may be useful for accelerating builds in sandboxes for expert users.
+
+library
+  hs-source-dirs: src
+  build-depends:
+    base                >= 4     && < 5,
+    base-orphans        >= 0.5.2 && < 1,
+    comonad             >= 4     && < 6,
+    containers          >= 0.1   && < 0.7,
+    template-haskell    >= 2.4   && < 2.15,
+    th-abstraction      >= 0.2.2 && < 0.4,
+    transformers        >= 0.2   && < 0.6
+
+  if !impl(ghc > 8.2)
+    build-depends: transformers-compat >= 0.5 && < 0.7
+
+  if flag(tagged)
+    build-depends: tagged >= 0.7.3 && < 1
+
+  if flag(semigroups) && !impl(ghc >= 8.0)
+    build-depends: semigroups >= 0.8.3.1 && < 1
+
+  if impl(ghc<7.9)
+    hs-source-dirs: old-src/ghc709
+    exposed-modules: Data.Bifunctor
+
+  if impl(ghc<8.1) && impl(eta<0.8.4)
+    hs-source-dirs: old-src/ghc801
+    exposed-modules:
+      Data.Bifoldable
+      Data.Bitraversable
+
+  if impl(ghc>=7.2) && impl(ghc<7.5)
+    build-depends: ghc-prim == 0.2.0.0
+
+  exposed-modules:
+    Data.Biapplicative
+    Data.Bifunctor.Biff
+    Data.Bifunctor.Clown
+    Data.Bifunctor.Fix
+    Data.Bifunctor.Flip
+    Data.Bifunctor.Functor
+    Data.Bifunctor.Join
+    Data.Bifunctor.Joker
+    Data.Bifunctor.Product
+    Data.Bifunctor.Sum
+    Data.Bifunctor.Tannen
+    Data.Bifunctor.TH
+    Data.Bifunctor.Wrapped
+
+  other-modules:
+    Data.Bifunctor.TH.Internal
+    Paths_bifunctors
+
+  ghc-options: -Wall
+
+
+test-suite bifunctors-spec
+  type: exitcode-stdio-1.0
+  hs-source-dirs: tests
+  main-is: Spec.hs
+  other-modules: BifunctorSpec
+  ghc-options: -Wall
+  build-tool-depends: hspec-discover:hspec-discover >= 1.8
+  build-depends:
+    base                >= 4   && < 5,
+    bifunctors,
+    hspec               >= 1.8,
+    QuickCheck          >= 2   && < 3,
+    template-haskell,
+    transformers,
+    transformers-compat
+

--- a/patches/bifunctors-5.5.4.patch
+++ b/patches/bifunctors-5.5.4.patch
@@ -1,0 +1,25 @@
+From 8f41b99fe71d94772d07ea286a869200f3f07d33 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 08:15:40 +0200
+Subject: [PATCH] Patched
+
+---
+ bifunctors.cabal | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bifunctors.cabal b/bifunctors.cabal
+index 448bb46..255850b 100644
+--- a/bifunctors.cabal
++++ b/bifunctors.cabal
+@@ -69,7 +69,7 @@ library
+     hs-source-dirs: old-src/ghc709
+     exposed-modules: Data.Bifunctor
+ 
+-  if impl(ghc<8.1)
++  if impl(ghc<8.1) && impl(eta<0.8.4)
+     hs-source-dirs: old-src/ghc801
+     exposed-modules:
+       Data.Bifoldable
+-- 
+2.16.2.windows.1
+

--- a/patches/cpphs-1.20.8.patch
+++ b/patches/cpphs-1.20.8.patch
@@ -1,0 +1,36 @@
+From 9ce5847d98bf31082b59b994cd5066c04e08091a Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 14:03:35 +0200
+Subject: [PATCH] Patched
+
+---
+ Language/Preprocessor/Cpphs/Options.hs | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/Language/Preprocessor/Cpphs/Options.hs b/Language/Preprocessor/Cpphs/Options.hs
+index 1d433eb..0231636 100644
+--- a/Language/Preprocessor/Cpphs/Options.hs
++++ b/Language/Preprocessor/Cpphs/Options.hs
+@@ -118,8 +118,8 @@ trailing :: (Eq a) => [a] -> [a] -> [a]
+ trailing xs = reverse . dropWhile (`elem`xs) . reverse
+ 
+ -- | Convert a list of RawOption to a BoolOptions structure.
+-boolOpts :: [RawOption] -> BoolOptions
+-boolOpts opts =
++makeBoolOpts :: [RawOption] -> BoolOptions
++makeBoolOpts opts =
+   BoolOptions
+     { macros    = not (NoMacro `elem` opts)
+     , locations = not (NoLine  `elem` opts)
+@@ -149,7 +149,7 @@ parseOptions xs = f ([], [], []) xs
+                            , defines  = [ x | Macro x <- reverse opts ]
+                            , includes = [ x | Path x  <- reverse opts ]
+                            , preInclude=[ x | PreInclude x <- reverse opts ]
+-                           , boolopts = boolOpts opts
++                           , boolopts = makeBoolOpts opts
+                            }
+     normalise ('/':'/':filepath) = normalise ('/':filepath)
+     normalise (x:filepath)       = x:normalise filepath
+-- 
+2.16.2.windows.1
+

--- a/patches/duckling-0.1.6.1.cabal
+++ b/patches/duckling-0.1.6.1.cabal
@@ -1,0 +1,1024 @@
+name:                duckling
+version:             0.1.6.1
+synopsis:            A Haskell library for parsing text into structured data.
+description:
+  Duckling is a library for parsing text into structured data.
+homepage:            https://github.com/facebook/duckling#readme
+bug-reports:         https://github.com/facebook/duckling/issues
+license:             OtherLicense
+license-files:       LICENSE,PATENTS
+author:              Facebook, Inc.
+maintainer:          duckling-team@fb.com
+copyright:           Copyright (c) 2014-present, Facebook, Inc.
+category:            Systems
+build-type:          Simple
+stability:           alpha
+cabal-version:       >=1.10
+tested-with:
+  GHC==8.0.2,
+  GHC==8.2.1
+
+extra-source-files:    README.md
+                     , PATENTS
+
+library
+  exposed-modules:     Duckling.Core
+                     , Duckling.Debug
+                     , Duckling.Testing.Types
+  -- ------------------------------------------------------------------
+  -- Core
+                     , Duckling.Api
+                     , Duckling.Engine
+                     , Duckling.Engine.Regex
+                     , Duckling.Locale
+                     , Duckling.Region
+                     , Duckling.Resolve
+                     , Duckling.Types
+                     , Duckling.Types.Document
+                     , Duckling.Types.Stash
+
+  -- ------------------------------------------------------------------
+  -- Rules
+                     , Duckling.Rules
+                     , Duckling.Rules.Common
+                     , Duckling.Rules.AR
+                     , Duckling.Rules.BG
+                     , Duckling.Rules.CS
+                     , Duckling.Rules.DA
+                     , Duckling.Rules.DE
+                     , Duckling.Rules.EL
+                     , Duckling.Rules.EN
+                     , Duckling.Rules.ES
+                     , Duckling.Rules.ET
+                     , Duckling.Rules.FR
+                     , Duckling.Rules.GA
+                     , Duckling.Rules.HE
+                     , Duckling.Rules.HI
+                     , Duckling.Rules.HR
+                     , Duckling.Rules.HU
+                     , Duckling.Rules.ID
+                     , Duckling.Rules.IT
+                     , Duckling.Rules.JA
+                     , Duckling.Rules.KA
+                     , Duckling.Rules.KO
+                     , Duckling.Rules.MY
+                     , Duckling.Rules.NB
+                     , Duckling.Rules.NE
+                     , Duckling.Rules.NL
+                     , Duckling.Rules.PL
+                     , Duckling.Rules.PT
+                     , Duckling.Rules.RO
+                     , Duckling.Rules.RU
+                     , Duckling.Rules.SV
+                     , Duckling.Rules.TA
+                     , Duckling.Rules.TR
+                     , Duckling.Rules.UK
+                     , Duckling.Rules.VI
+                     , Duckling.Rules.ZH
+
+  -- ------------------------------------------------------------------
+  -- Ranking
+                     , Duckling.Ranking.Types
+                     , Duckling.Ranking.Extraction
+                     , Duckling.Ranking.Rank
+                     , Duckling.Ranking.Classifiers
+                     , Duckling.Ranking.Classifiers.AR_XX
+                     , Duckling.Ranking.Classifiers.BG_XX
+                     , Duckling.Ranking.Classifiers.CS_XX
+                     , Duckling.Ranking.Classifiers.DA_XX
+                     , Duckling.Ranking.Classifiers.DE_XX
+                     , Duckling.Ranking.Classifiers.EL_XX
+                     , Duckling.Ranking.Classifiers.EN_CA
+                     , Duckling.Ranking.Classifiers.EN_GB
+                     , Duckling.Ranking.Classifiers.EN_US
+                     , Duckling.Ranking.Classifiers.EN_XX
+                     , Duckling.Ranking.Classifiers.ES_XX
+                     , Duckling.Ranking.Classifiers.ET_XX
+                     , Duckling.Ranking.Classifiers.FR_XX
+                     , Duckling.Ranking.Classifiers.GA_XX
+                     , Duckling.Ranking.Classifiers.HE_XX
+                     , Duckling.Ranking.Classifiers.HI_XX
+                     , Duckling.Ranking.Classifiers.HR_XX
+                     , Duckling.Ranking.Classifiers.HU_XX
+                     , Duckling.Ranking.Classifiers.ID_XX
+                     , Duckling.Ranking.Classifiers.IT_XX
+                     , Duckling.Ranking.Classifiers.JA_XX
+                     , Duckling.Ranking.Classifiers.KA_XX
+                     , Duckling.Ranking.Classifiers.KO_XX
+                     , Duckling.Ranking.Classifiers.MY_XX
+                     , Duckling.Ranking.Classifiers.NB_XX
+                     , Duckling.Ranking.Classifiers.NE_XX
+                     , Duckling.Ranking.Classifiers.NL_BE
+                     , Duckling.Ranking.Classifiers.NL_NL
+                     , Duckling.Ranking.Classifiers.NL_XX
+                     , Duckling.Ranking.Classifiers.PL_XX
+                     , Duckling.Ranking.Classifiers.PT_XX
+                     , Duckling.Ranking.Classifiers.RO_XX
+                     , Duckling.Ranking.Classifiers.RU_XX
+                     , Duckling.Ranking.Classifiers.SV_XX
+                     , Duckling.Ranking.Classifiers.TA_XX
+                     , Duckling.Ranking.Classifiers.TR_XX
+                     , Duckling.Ranking.Classifiers.UK_XX
+                     , Duckling.Ranking.Classifiers.VI_XX
+                     , Duckling.Ranking.Classifiers.ZH_CN
+                     , Duckling.Ranking.Classifiers.ZH_HK
+                     , Duckling.Ranking.Classifiers.ZH_MO
+                     , Duckling.Ranking.Classifiers.ZH_TW
+                     , Duckling.Ranking.Classifiers.ZH_XX
+
+  -- ------------------------------------------------------------------
+  -- Dimensions
+                     , Duckling.Dimensions
+                     , Duckling.Dimensions.Common
+                     , Duckling.Dimensions.Types
+                     , Duckling.Dimensions.AR
+                     , Duckling.Dimensions.BG
+                     , Duckling.Dimensions.CS
+                     , Duckling.Dimensions.DA
+                     , Duckling.Dimensions.DE
+                     , Duckling.Dimensions.EL
+                     , Duckling.Dimensions.EN
+                     , Duckling.Dimensions.ES
+                     , Duckling.Dimensions.ET
+                     , Duckling.Dimensions.FR
+                     , Duckling.Dimensions.GA
+                     , Duckling.Dimensions.HE
+                     , Duckling.Dimensions.HI
+                     , Duckling.Dimensions.HR
+                     , Duckling.Dimensions.HU
+                     , Duckling.Dimensions.ID
+                     , Duckling.Dimensions.IT
+                     , Duckling.Dimensions.JA
+                     , Duckling.Dimensions.KA
+                     , Duckling.Dimensions.KO
+                     , Duckling.Dimensions.MY
+                     , Duckling.Dimensions.NB
+                     , Duckling.Dimensions.NE
+                     , Duckling.Dimensions.NL
+                     , Duckling.Dimensions.PL
+                     , Duckling.Dimensions.PT
+                     , Duckling.Dimensions.RO
+                     , Duckling.Dimensions.RU
+                     , Duckling.Dimensions.SV
+                     , Duckling.Dimensions.TA
+                     , Duckling.Dimensions.TR
+                     , Duckling.Dimensions.UK
+                     , Duckling.Dimensions.VI
+                     , Duckling.Dimensions.ZH
+
+                     -- AmountOfMoney
+                     , Duckling.AmountOfMoney.AR.Corpus
+                     , Duckling.AmountOfMoney.AR.Rules
+                     , Duckling.AmountOfMoney.EN.AU.Corpus
+                     , Duckling.AmountOfMoney.EN.AU.Rules
+                     , Duckling.AmountOfMoney.EN.BZ.Corpus
+                     , Duckling.AmountOfMoney.EN.BZ.Rules
+                     , Duckling.AmountOfMoney.EN.CA.Corpus
+                     , Duckling.AmountOfMoney.EN.CA.Rules
+                     , Duckling.AmountOfMoney.EN.Corpus
+                     , Duckling.AmountOfMoney.EN.GB.Corpus
+                     , Duckling.AmountOfMoney.EN.GB.Rules
+                     , Duckling.AmountOfMoney.EN.IE.Corpus
+                     , Duckling.AmountOfMoney.EN.IE.Rules
+                     , Duckling.AmountOfMoney.EN.IN.Corpus
+                     , Duckling.AmountOfMoney.EN.IN.Rules
+                     , Duckling.AmountOfMoney.EN.JM.Corpus
+                     , Duckling.AmountOfMoney.EN.JM.Rules
+                     , Duckling.AmountOfMoney.EN.NZ.Corpus
+                     , Duckling.AmountOfMoney.EN.NZ.Rules
+                     , Duckling.AmountOfMoney.EN.PH.Corpus
+                     , Duckling.AmountOfMoney.EN.PH.Rules
+                     , Duckling.AmountOfMoney.EN.Rules
+                     , Duckling.AmountOfMoney.EN.TT.Corpus
+                     , Duckling.AmountOfMoney.EN.TT.Rules
+                     , Duckling.AmountOfMoney.EN.US.Corpus
+                     , Duckling.AmountOfMoney.EN.US.Rules
+                     , Duckling.AmountOfMoney.EN.ZA.Corpus
+                     , Duckling.AmountOfMoney.EN.ZA.Rules
+                     , Duckling.AmountOfMoney.BG.Corpus
+                     , Duckling.AmountOfMoney.BG.Rules
+                     , Duckling.AmountOfMoney.ES.Corpus
+                     , Duckling.AmountOfMoney.ES.Rules
+                     , Duckling.AmountOfMoney.FR.Corpus
+                     , Duckling.AmountOfMoney.FR.Rules
+                     , Duckling.AmountOfMoney.GA.Corpus
+                     , Duckling.AmountOfMoney.GA.Rules
+                     , Duckling.AmountOfMoney.HR.Corpus
+                     , Duckling.AmountOfMoney.HR.Rules
+                     , Duckling.AmountOfMoney.ID.Corpus
+                     , Duckling.AmountOfMoney.ID.Rules
+                     , Duckling.AmountOfMoney.KO.Corpus
+                     , Duckling.AmountOfMoney.KO.Rules
+                     , Duckling.AmountOfMoney.NB.Corpus
+                     , Duckling.AmountOfMoney.NB.Rules
+                     , Duckling.AmountOfMoney.PT.Corpus
+                     , Duckling.AmountOfMoney.PT.Rules
+                     , Duckling.AmountOfMoney.RO.Corpus
+                     , Duckling.AmountOfMoney.RO.Rules
+                     , Duckling.AmountOfMoney.RU.Corpus
+                     , Duckling.AmountOfMoney.RU.Rules
+                     , Duckling.AmountOfMoney.SV.Corpus
+                     , Duckling.AmountOfMoney.SV.Rules
+                     , Duckling.AmountOfMoney.VI.Corpus
+                     , Duckling.AmountOfMoney.VI.Rules
+                     , Duckling.AmountOfMoney.NL.Corpus
+                     , Duckling.AmountOfMoney.NL.Rules
+                     , Duckling.AmountOfMoney.ZH.Corpus
+                     , Duckling.AmountOfMoney.ZH.Rules
+                     , Duckling.AmountOfMoney.Helpers
+                     , Duckling.AmountOfMoney.Rules
+                     , Duckling.AmountOfMoney.Types
+
+                     -- Distance
+                     , Duckling.Distance.BG.Corpus
+                     , Duckling.Distance.BG.Rules
+                     , Duckling.Distance.CS.Corpus
+                     , Duckling.Distance.CS.Rules
+                     , Duckling.Distance.EN.Corpus
+                     , Duckling.Distance.EN.Rules
+                     , Duckling.Distance.ES.Corpus
+                     , Duckling.Distance.ES.Rules
+                     , Duckling.Distance.FR.Corpus
+                     , Duckling.Distance.FR.Rules
+                     , Duckling.Distance.GA.Corpus
+                     , Duckling.Distance.GA.Rules
+                     , Duckling.Distance.HR.Corpus
+                     , Duckling.Distance.HR.Rules
+                     , Duckling.Distance.KO.Corpus
+                     , Duckling.Distance.KO.Rules
+                     , Duckling.Distance.PT.Corpus
+                     , Duckling.Distance.PT.Rules
+                     , Duckling.Distance.NL.Corpus
+                     , Duckling.Distance.NL.Rules
+                     , Duckling.Distance.RO.Corpus
+                     , Duckling.Distance.RO.Rules
+                     , Duckling.Distance.RU.Corpus
+                     , Duckling.Distance.RU.Rules
+                     , Duckling.Distance.TR.Corpus
+                     , Duckling.Distance.TR.Rules
+                     , Duckling.Distance.SV.Corpus
+                     , Duckling.Distance.SV.Rules
+                     , Duckling.Distance.ZH.Corpus
+                     , Duckling.Distance.ZH.Rules
+                     , Duckling.Distance.Helpers
+                     , Duckling.Distance.Rules
+                     , Duckling.Distance.Types
+
+                     -- Duration
+                     , Duckling.Duration.AR.Corpus
+                     , Duckling.Duration.AR.Rules
+                     , Duckling.Duration.BG.Corpus
+                     , Duckling.Duration.BG.Rules
+                     , Duckling.Duration.DA.Rules
+                     , Duckling.Duration.DE.Rules
+                     , Duckling.Duration.EL.Corpus
+                     , Duckling.Duration.EL.Rules
+                     , Duckling.Duration.EN.Corpus
+                     , Duckling.Duration.EN.Rules
+                     , Duckling.Duration.FR.Corpus
+                     , Duckling.Duration.FR.Rules
+                     , Duckling.Duration.GA.Corpus
+                     , Duckling.Duration.GA.Rules
+                     , Duckling.Duration.HE.Rules
+                     , Duckling.Duration.HI.Corpus
+                     , Duckling.Duration.HI.Rules
+                     , Duckling.Duration.HR.Rules
+                     , Duckling.Duration.HU.Corpus
+                     , Duckling.Duration.HU.Rules
+                     , Duckling.Duration.IT.Rules
+                     , Duckling.Duration.JA.Corpus
+                     , Duckling.Duration.KO.Corpus
+                     , Duckling.Duration.KO.Rules
+                     , Duckling.Duration.NB.Corpus
+                     , Duckling.Duration.NB.Rules
+                     , Duckling.Duration.NL.Corpus
+                     , Duckling.Duration.NL.Rules
+                     , Duckling.Duration.PL.Corpus
+                     , Duckling.Duration.PL.Rules
+                     , Duckling.Duration.PT.Corpus
+                     , Duckling.Duration.SV.Corpus
+                     , Duckling.Duration.SV.Rules
+                     , Duckling.Duration.ZH.Corpus
+                     , Duckling.Duration.RO.Corpus
+                     , Duckling.Duration.RO.Rules
+                     , Duckling.Duration.RU.Corpus
+                     , Duckling.Duration.RU.Rules
+                     , Duckling.Duration.TR.Corpus
+                     , Duckling.Duration.TR.Rules
+                     , Duckling.Duration.Helpers
+                     , Duckling.Duration.Rules
+                     , Duckling.Duration.Types
+
+                     -- Email
+                     , Duckling.Email.EN.Corpus
+                     , Duckling.Email.EN.Rules
+                     , Duckling.Email.FR.Corpus
+                     , Duckling.Email.FR.Rules
+                     , Duckling.Email.IT.Corpus
+                     , Duckling.Email.IT.Rules
+                     , Duckling.Email.Corpus
+                     , Duckling.Email.Rules
+                     , Duckling.Email.Types
+
+                     -- Numeral
+                     , Duckling.Numeral.AR.Corpus
+                     , Duckling.Numeral.AR.Rules
+                     , Duckling.Numeral.BG.Corpus
+                     , Duckling.Numeral.BG.Rules
+                     , Duckling.Numeral.CS.Corpus
+                     , Duckling.Numeral.CS.Rules
+                     , Duckling.Numeral.DA.Corpus
+                     , Duckling.Numeral.DA.Rules
+                     , Duckling.Numeral.DE.Corpus
+                     , Duckling.Numeral.DE.Rules
+                     , Duckling.Numeral.EL.Corpus
+                     , Duckling.Numeral.EL.Rules
+                     , Duckling.Numeral.EN.Corpus
+                     , Duckling.Numeral.EN.Rules
+                     , Duckling.Numeral.ES.Corpus
+                     , Duckling.Numeral.ES.Rules
+                     , Duckling.Numeral.ET.Corpus
+                     , Duckling.Numeral.ET.Rules
+                     , Duckling.Numeral.FR.Corpus
+                     , Duckling.Numeral.FR.Rules
+                     , Duckling.Numeral.GA.Corpus
+                     , Duckling.Numeral.GA.Rules
+                     , Duckling.Numeral.HE.Corpus
+                     , Duckling.Numeral.HE.Rules
+                     , Duckling.Numeral.HI.Corpus
+                     , Duckling.Numeral.HI.Rules
+                     , Duckling.Numeral.HR.Corpus
+                     , Duckling.Numeral.HR.Rules
+                     , Duckling.Numeral.HU.Corpus
+                     , Duckling.Numeral.HU.Rules
+                     , Duckling.Numeral.ID.Corpus
+                     , Duckling.Numeral.ID.Rules
+                     , Duckling.Numeral.IT.Corpus
+                     , Duckling.Numeral.IT.Rules
+                     , Duckling.Numeral.JA.Corpus
+                     , Duckling.Numeral.JA.Rules
+                     , Duckling.Numeral.KA.Corpus
+                     , Duckling.Numeral.KA.Rules
+                     , Duckling.Numeral.KO.Corpus
+                     , Duckling.Numeral.KO.Rules
+                     , Duckling.Numeral.MY.Corpus
+                     , Duckling.Numeral.MY.Rules
+                     , Duckling.Numeral.NB.Corpus
+                     , Duckling.Numeral.NB.Rules
+                     , Duckling.Numeral.NE.Corpus
+                     , Duckling.Numeral.NE.Rules
+                     , Duckling.Numeral.NL.Corpus
+                     , Duckling.Numeral.NL.Rules
+                     , Duckling.Numeral.PL.Corpus
+                     , Duckling.Numeral.PL.Rules
+                     , Duckling.Numeral.PT.Corpus
+                     , Duckling.Numeral.PT.Rules
+                     , Duckling.Numeral.RU.Corpus
+                     , Duckling.Numeral.RU.Rules
+                     , Duckling.Numeral.SV.Corpus
+                     , Duckling.Numeral.SV.Rules
+                     , Duckling.Numeral.TA.Corpus
+                     , Duckling.Numeral.TA.Rules
+                     , Duckling.Numeral.TR.Corpus
+                     , Duckling.Numeral.TR.Rules
+                     , Duckling.Numeral.UK.Corpus
+                     , Duckling.Numeral.UK.Rules
+                     , Duckling.Numeral.VI.Corpus
+                     , Duckling.Numeral.VI.Rules
+                     , Duckling.Numeral.ZH.Corpus
+                     , Duckling.Numeral.ZH.Rules
+                     , Duckling.Numeral.RO.Corpus
+                     , Duckling.Numeral.RO.Rules
+                     , Duckling.Numeral.Helpers
+                     , Duckling.Numeral.Rules
+                     , Duckling.Numeral.Types
+
+                     -- Ordinal
+                     , Duckling.Ordinal.AR.Corpus
+                     , Duckling.Ordinal.AR.Rules
+                     , Duckling.Ordinal.BG.Corpus
+                     , Duckling.Ordinal.BG.Rules
+                     , Duckling.Ordinal.DA.Corpus
+                     , Duckling.Ordinal.DA.Rules
+                     , Duckling.Ordinal.DE.Corpus
+                     , Duckling.Ordinal.DE.Rules
+                     , Duckling.Ordinal.EL.Corpus
+                     , Duckling.Ordinal.EL.Rules
+                     , Duckling.Ordinal.EN.Corpus
+                     , Duckling.Ordinal.EN.Rules
+                     , Duckling.Ordinal.ES.Corpus
+                     , Duckling.Ordinal.ES.Rules
+                     , Duckling.Ordinal.ET.Corpus
+                     , Duckling.Ordinal.ET.Rules
+                     , Duckling.Ordinal.FR.Corpus
+                     , Duckling.Ordinal.FR.Rules
+                     , Duckling.Ordinal.GA.Corpus
+                     , Duckling.Ordinal.GA.Rules
+                     , Duckling.Ordinal.HE.Corpus
+                     , Duckling.Ordinal.HE.Rules
+                     , Duckling.Ordinal.HI.Corpus
+                     , Duckling.Ordinal.HI.Rules
+                     , Duckling.Ordinal.HR.Corpus
+                     , Duckling.Ordinal.HR.Rules
+                     , Duckling.Ordinal.HU.Corpus
+                     , Duckling.Ordinal.HU.Rules
+                     , Duckling.Ordinal.ID.Corpus
+                     , Duckling.Ordinal.ID.Rules
+                     , Duckling.Ordinal.IT.Corpus
+                     , Duckling.Ordinal.IT.Rules
+                     , Duckling.Ordinal.JA.Corpus
+                     , Duckling.Ordinal.JA.Rules
+                     , Duckling.Ordinal.KO.Corpus
+                     , Duckling.Ordinal.KO.Rules
+                     , Duckling.Ordinal.NB.Corpus
+                     , Duckling.Ordinal.NB.Rules
+                     , Duckling.Ordinal.NL.Corpus
+                     , Duckling.Ordinal.NL.Rules
+                     , Duckling.Ordinal.PL.Corpus
+                     , Duckling.Ordinal.PL.Rules
+                     , Duckling.Ordinal.PT.Corpus
+                     , Duckling.Ordinal.PT.Rules
+                     , Duckling.Ordinal.RO.Corpus
+                     , Duckling.Ordinal.RO.Rules
+                     , Duckling.Ordinal.RU.Corpus
+                     , Duckling.Ordinal.RU.Rules
+                     , Duckling.Ordinal.SV.Corpus
+                     , Duckling.Ordinal.SV.Rules
+                     , Duckling.Ordinal.TR.Corpus
+                     , Duckling.Ordinal.TR.Rules
+                     , Duckling.Ordinal.UK.Corpus
+                     , Duckling.Ordinal.UK.Rules
+                     , Duckling.Ordinal.VI.Corpus
+                     , Duckling.Ordinal.VI.Rules
+                     , Duckling.Ordinal.ZH.Corpus
+                     , Duckling.Ordinal.ZH.Rules
+                     , Duckling.Ordinal.Helpers
+                     , Duckling.Ordinal.Types
+
+                     -- PhoneNumber
+                     , Duckling.PhoneNumber.PT.Corpus
+                     , Duckling.PhoneNumber.PT.Rules
+                     , Duckling.PhoneNumber.Corpus
+                     , Duckling.PhoneNumber.Rules
+                     , Duckling.PhoneNumber.Types
+
+                     -- Quantity
+                     , Duckling.Quantity.AR.Corpus
+                     , Duckling.Quantity.AR.Rules
+                     , Duckling.Quantity.EN.Corpus
+                     , Duckling.Quantity.EN.Rules
+                     , Duckling.Quantity.FR.Corpus
+                     , Duckling.Quantity.FR.Rules
+                     , Duckling.Quantity.HR.Corpus
+                     , Duckling.Quantity.HR.Rules
+                     , Duckling.Quantity.KO.Corpus
+                     , Duckling.Quantity.KO.Rules
+                     , Duckling.Quantity.PT.Corpus
+                     , Duckling.Quantity.PT.Rules
+                     , Duckling.Quantity.RO.Corpus
+                     , Duckling.Quantity.RO.Rules
+                     , Duckling.Quantity.RU.Corpus
+                     , Duckling.Quantity.RU.Rules
+                     , Duckling.Quantity.ZH.Corpus
+                     , Duckling.Quantity.ZH.Rules
+                     , Duckling.Quantity.Helpers
+                     , Duckling.Quantity.Types
+
+                     -- Regex
+                     , Duckling.Regex.Types
+
+                     -- Temperature
+                     , Duckling.Temperature.AR.Corpus
+                     , Duckling.Temperature.AR.Rules
+                     , Duckling.Temperature.EN.Corpus
+                     , Duckling.Temperature.EN.Rules
+                     , Duckling.Temperature.ES.Corpus
+                     , Duckling.Temperature.ES.Rules
+                     , Duckling.Temperature.FR.Corpus
+                     , Duckling.Temperature.FR.Rules
+                     , Duckling.Temperature.GA.Corpus
+                     , Duckling.Temperature.GA.Rules
+                     , Duckling.Temperature.HR.Corpus
+                     , Duckling.Temperature.HR.Rules
+                     , Duckling.Temperature.IT.Corpus
+                     , Duckling.Temperature.IT.Rules
+                     , Duckling.Temperature.JA.Corpus
+                     , Duckling.Temperature.JA.Rules
+                     , Duckling.Temperature.KO.Corpus
+                     , Duckling.Temperature.KO.Rules
+                     , Duckling.Temperature.PT.Corpus
+                     , Duckling.Temperature.PT.Rules
+                     , Duckling.Temperature.RO.Corpus
+                     , Duckling.Temperature.RO.Rules
+                     , Duckling.Temperature.TR.Corpus
+                     , Duckling.Temperature.TR.Rules
+                     , Duckling.Temperature.ZH.Corpus
+                     , Duckling.Temperature.ZH.Rules
+                     , Duckling.Temperature.Helpers
+                     , Duckling.Temperature.Rules
+                     , Duckling.Temperature.Types
+
+                     -- Time
+                     , Duckling.Time.AR.Corpus
+                     , Duckling.Time.AR.Rules
+                     , Duckling.Time.DA.Corpus
+                     , Duckling.Time.DA.Rules
+                     , Duckling.Time.DE.Corpus
+                     , Duckling.Time.DE.Rules
+                     , Duckling.Time.EL.Corpus
+                     , Duckling.Time.EL.Rules
+                     , Duckling.Time.EN.Corpus
+                     , Duckling.Time.EN.Rules
+                     , Duckling.Time.EN.AU.Corpus
+                     , Duckling.Time.EN.AU.Rules
+                     , Duckling.Time.EN.BZ.Corpus
+                     , Duckling.Time.EN.BZ.Rules
+                     , Duckling.Time.EN.CA.Corpus
+                     , Duckling.Time.EN.CA.Rules
+                     , Duckling.Time.EN.GB.Corpus
+                     , Duckling.Time.EN.GB.Rules
+                     , Duckling.Time.EN.IE.Corpus
+                     , Duckling.Time.EN.IE.Rules
+                     , Duckling.Time.EN.IN.Corpus
+                     , Duckling.Time.EN.IN.Rules
+                     , Duckling.Time.EN.JM.Corpus
+                     , Duckling.Time.EN.JM.Rules
+                     , Duckling.Time.EN.NZ.Corpus
+                     , Duckling.Time.EN.NZ.Rules
+                     , Duckling.Time.EN.PH.Corpus
+                     , Duckling.Time.EN.PH.Rules
+                     , Duckling.Time.EN.TT.Corpus
+                     , Duckling.Time.EN.TT.Rules
+                     , Duckling.Time.EN.US.Corpus
+                     , Duckling.Time.EN.US.Rules
+                     , Duckling.Time.EN.ZA.Corpus
+                     , Duckling.Time.EN.ZA.Rules
+                     , Duckling.Time.ES.Corpus
+                     , Duckling.Time.ES.Rules
+                     , Duckling.Time.FR.Corpus
+                     , Duckling.Time.FR.Rules
+                     , Duckling.Time.GA.Corpus
+                     , Duckling.Time.GA.Rules
+                     , Duckling.Time.HR.Corpus
+                     , Duckling.Time.HR.Rules
+                     , Duckling.Time.HE.Corpus
+                     , Duckling.Time.HE.Rules
+                     , Duckling.Time.HU.Corpus
+                     , Duckling.Time.HU.Rules
+                     , Duckling.Time.IT.Corpus
+                     , Duckling.Time.IT.Rules
+                     , Duckling.Time.KO.Corpus
+                     , Duckling.Time.KO.Rules
+                     , Duckling.Time.NB.Corpus
+                     , Duckling.Time.NB.Rules
+                     , Duckling.Time.NL.Corpus
+                     , Duckling.Time.NL.Rules
+                     , Duckling.Time.NL.BE.Corpus
+                     , Duckling.Time.NL.BE.Rules
+                     , Duckling.Time.NL.NL.Rules
+                     , Duckling.Time.PL.Corpus
+                     , Duckling.Time.PL.Rules
+                     , Duckling.Time.PT.Corpus
+                     , Duckling.Time.PT.Rules
+                     , Duckling.Time.RO.Corpus
+                     , Duckling.Time.RO.Rules
+                     , Duckling.Time.SV.Corpus
+                     , Duckling.Time.SV.Rules
+                     , Duckling.Time.VI.Corpus
+                     , Duckling.Time.VI.Rules
+                     , Duckling.Time.ZH.Corpus
+                     , Duckling.Time.ZH.Rules
+                     , Duckling.Time.ZH.CN.Corpus
+                     , Duckling.Time.ZH.CN.Rules
+                     , Duckling.Time.ZH.HK.Corpus
+                     , Duckling.Time.ZH.HK.Rules
+                     , Duckling.Time.ZH.MO.Corpus
+                     , Duckling.Time.ZH.MO.Rules
+                     , Duckling.Time.ZH.TW.Corpus
+                     , Duckling.Time.ZH.TW.Rules
+                     , Duckling.Time.Computed
+                     , Duckling.Time.Corpus
+                     , Duckling.Time.Helpers
+                     , Duckling.Time.Types
+                     -- REMOVE ME
+                     , Duckling.Time.TimeZone.Parse
+
+                     -- TimeGrain
+                     , Duckling.TimeGrain.AR.Rules
+                     , Duckling.TimeGrain.BG.Rules
+                     , Duckling.TimeGrain.DA.Rules
+                     , Duckling.TimeGrain.DE.Rules
+                     , Duckling.TimeGrain.EN.Rules
+                     , Duckling.TimeGrain.EL.Rules
+                     , Duckling.TimeGrain.ES.Rules
+                     , Duckling.TimeGrain.FR.Rules
+                     , Duckling.TimeGrain.GA.Rules
+                     , Duckling.TimeGrain.HE.Rules
+                     , Duckling.TimeGrain.HI.Rules
+                     , Duckling.TimeGrain.HR.Rules
+                     , Duckling.TimeGrain.HU.Rules
+                     , Duckling.TimeGrain.IT.Rules
+                     , Duckling.TimeGrain.JA.Rules
+                     , Duckling.TimeGrain.KO.Rules
+                     , Duckling.TimeGrain.NB.Rules
+                     , Duckling.TimeGrain.NL.Rules
+                     , Duckling.TimeGrain.PL.Rules
+                     , Duckling.TimeGrain.PT.Rules
+                     , Duckling.TimeGrain.RO.Rules
+                     , Duckling.TimeGrain.RU.Rules
+                     , Duckling.TimeGrain.SV.Rules
+                     , Duckling.TimeGrain.TR.Rules
+                     , Duckling.TimeGrain.VI.Rules
+                     , Duckling.TimeGrain.ZH.Rules
+                     , Duckling.TimeGrain.Types
+
+                     -- Url
+                     , Duckling.Url.Corpus
+                     , Duckling.Url.Helpers
+                     , Duckling.Url.Rules
+                     , Duckling.Url.Types
+
+                     -- Volume
+                     , Duckling.Volume.AR.Corpus
+                     , Duckling.Volume.AR.Rules
+                     , Duckling.Volume.EN.Corpus
+                     , Duckling.Volume.EN.Rules
+                     , Duckling.Volume.ES.Corpus
+                     , Duckling.Volume.ES.Rules
+                     , Duckling.Volume.FR.Corpus
+                     , Duckling.Volume.FR.Rules
+                     , Duckling.Volume.GA.Corpus
+                     , Duckling.Volume.GA.Rules
+                     , Duckling.Volume.HR.Corpus
+                     , Duckling.Volume.HR.Rules
+                     , Duckling.Volume.IT.Corpus
+                     , Duckling.Volume.IT.Rules
+                     , Duckling.Volume.KO.Corpus
+                     , Duckling.Volume.KO.Rules
+                     , Duckling.Volume.PT.Corpus
+                     , Duckling.Volume.PT.Rules
+                     , Duckling.Volume.NL.Corpus
+                     , Duckling.Volume.NL.Rules
+                     , Duckling.Volume.RO.Corpus
+                     , Duckling.Volume.RO.Rules
+                     , Duckling.Volume.RU.Corpus
+                     , Duckling.Volume.RU.Rules
+                     , Duckling.Volume.TR.Corpus
+                     , Duckling.Volume.TR.Rules
+                     , Duckling.Volume.Helpers
+                     , Duckling.Volume.Rules
+                     , Duckling.Volume.Types
+  build-depends:       base                  >= 4.8.2 && < 5.0
+                     , array                 >= 0.5.1.1 && < 0.6
+                     , attoparsec            >= 0.13.1.0 && < 0.14
+                     , aeson                 >= 0.11.3.0 && < 1.3
+                     , bytestring            >= 0.10.6.0 && < 0.11
+                     , containers            >= 0.5.6.2 && < 0.6
+                     , deepseq               >= 1.4.1.1 && < 1.5
+                     , dependent-sum         >= 0.3.2.2 && < 0.5
+                     , extra                 >= 1.4.10 && < 1.7
+                     , hashable              >= 1.2.4.0 && < 1.3
+                     , regex-base            >= 0.93.2 && < 0.94
+                     , regex-pcre-builtin    >= 0.94.4 && < 0.95
+                     , text                  >= 1.2.2.1 && < 1.3
+                     , text-show             >= 2.1.2 && < 3.9
+                     , time                  >= 1.5.0.1 && < 1.9
+                     , timezone-series       >= 0.1.5.1 && < 0.2
+                     , unordered-containers  >= 0.2.7.2 && < 0.3
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+test-suite duckling-test
+  type:                exitcode-stdio-1.0
+  main-is:             TestMain.hs
+  hs-source-dirs:      tests
+  build-depends:       duckling
+                     , base
+                     , aeson
+                     , text
+                     , time
+                     , unordered-containers
+                     , tasty                 >= 0.11.1 && < 0.12
+                     , tasty-hunit           >= 0.9.2 && < 1.0
+  other-modules:       Duckling.Tests
+                     , Duckling.Testing.Asserts
+
+                     , Duckling.Api.Tests
+                     , Duckling.Engine.Tests
+
+  -- ------------------------------------------------------------------
+  -- Dimensions
+                     , Duckling.Dimensions.Tests
+
+                     -- AmountOfMoney
+                     , Duckling.AmountOfMoney.AR.Tests
+                     , Duckling.AmountOfMoney.EN.Tests
+                     , Duckling.AmountOfMoney.BG.Tests
+                     , Duckling.AmountOfMoney.ES.Tests
+                     , Duckling.AmountOfMoney.FR.Tests
+                     , Duckling.AmountOfMoney.GA.Tests
+                     , Duckling.AmountOfMoney.HR.Tests
+                     , Duckling.AmountOfMoney.ID.Tests
+                     , Duckling.AmountOfMoney.KO.Tests
+                     , Duckling.AmountOfMoney.NB.Tests
+                     , Duckling.AmountOfMoney.PT.Tests
+                     , Duckling.AmountOfMoney.RO.Tests
+                     , Duckling.AmountOfMoney.RU.Tests
+                     , Duckling.AmountOfMoney.SV.Tests
+                     , Duckling.AmountOfMoney.VI.Tests
+                     , Duckling.AmountOfMoney.NL.Tests
+                     , Duckling.AmountOfMoney.ZH.Tests
+                     , Duckling.AmountOfMoney.Tests
+
+                     -- Distance
+                     , Duckling.Distance.BG.Tests
+                     , Duckling.Distance.CS.Tests
+                     , Duckling.Distance.EN.Tests
+                     , Duckling.Distance.ES.Tests
+                     , Duckling.Distance.FR.Tests
+                     , Duckling.Distance.GA.Tests
+                     , Duckling.Distance.HR.Tests
+                     , Duckling.Distance.KO.Tests
+                     , Duckling.Distance.NL.Tests
+                     , Duckling.Distance.PT.Tests
+                     , Duckling.Distance.RO.Tests
+                     , Duckling.Distance.RU.Tests
+                     , Duckling.Distance.TR.Tests
+                     , Duckling.Distance.SV.Tests
+                     , Duckling.Distance.ZH.Tests
+                     , Duckling.Distance.Tests
+
+                     -- Duration
+                     , Duckling.Duration.AR.Tests
+                     , Duckling.Duration.BG.Tests
+                     , Duckling.Duration.EL.Tests
+                     , Duckling.Duration.EN.Tests
+                     , Duckling.Duration.FR.Tests
+                     , Duckling.Duration.GA.Tests
+                     , Duckling.Duration.HU.Tests
+                     , Duckling.Duration.HI.Tests
+                     , Duckling.Duration.JA.Tests
+                     , Duckling.Duration.KO.Tests
+                     , Duckling.Duration.NB.Tests
+                     , Duckling.Duration.NL.Tests
+                     , Duckling.Duration.PL.Tests
+                     , Duckling.Duration.PT.Tests
+                     , Duckling.Duration.RO.Tests
+                     , Duckling.Duration.RU.Tests
+                     , Duckling.Duration.SV.Tests
+                     , Duckling.Duration.TR.Tests
+                     , Duckling.Duration.ZH.Tests
+                     , Duckling.Duration.Tests
+
+                     -- Email
+                     , Duckling.Email.EN.Tests
+                     , Duckling.Email.FR.Tests
+                     , Duckling.Email.IT.Tests
+                     , Duckling.Email.Tests
+
+                     -- Numeral
+                     , Duckling.Numeral.AR.Tests
+                     , Duckling.Numeral.BG.Tests
+                     , Duckling.Numeral.CS.Tests
+                     , Duckling.Numeral.DA.Tests
+                     , Duckling.Numeral.DE.Tests
+                     , Duckling.Numeral.EL.Tests
+                     , Duckling.Numeral.EN.Tests
+                     , Duckling.Numeral.ES.Tests
+                     , Duckling.Numeral.ET.Tests
+                     , Duckling.Numeral.FR.Tests
+                     , Duckling.Numeral.GA.Tests
+                     , Duckling.Numeral.HE.Tests
+                     , Duckling.Numeral.HI.Tests
+                     , Duckling.Numeral.HR.Tests
+                     , Duckling.Numeral.HU.Tests
+                     , Duckling.Numeral.ID.Tests
+                     , Duckling.Numeral.IT.Tests
+                     , Duckling.Numeral.JA.Tests
+                     , Duckling.Numeral.KA.Tests
+                     , Duckling.Numeral.KO.Tests
+                     , Duckling.Numeral.MY.Tests
+                     , Duckling.Numeral.NB.Tests
+                     , Duckling.Numeral.NE.Tests
+                     , Duckling.Numeral.NL.Tests
+                     , Duckling.Numeral.PL.Tests
+                     , Duckling.Numeral.PT.Tests
+                     , Duckling.Numeral.RO.Tests
+                     , Duckling.Numeral.RU.Tests
+                     , Duckling.Numeral.SV.Tests
+                     , Duckling.Numeral.TA.Tests
+                     , Duckling.Numeral.TR.Tests
+                     , Duckling.Numeral.UK.Tests
+                     , Duckling.Numeral.VI.Tests
+                     , Duckling.Numeral.ZH.Tests
+                     , Duckling.Numeral.Tests
+
+                     -- Ordinal
+                     , Duckling.Ordinal.AR.Tests
+                     , Duckling.Ordinal.BG.Tests
+                     , Duckling.Ordinal.DA.Tests
+                     , Duckling.Ordinal.DE.Tests
+                     , Duckling.Ordinal.EL.Tests
+                     , Duckling.Ordinal.EN.Tests
+                     , Duckling.Ordinal.ES.Tests
+                     , Duckling.Ordinal.ET.Tests
+                     , Duckling.Ordinal.FR.Tests
+                     , Duckling.Ordinal.GA.Tests
+                     , Duckling.Ordinal.HE.Tests
+                     , Duckling.Ordinal.HI.Tests
+                     , Duckling.Ordinal.HR.Tests
+                     , Duckling.Ordinal.HU.Tests
+                     , Duckling.Ordinal.ID.Tests
+                     , Duckling.Ordinal.IT.Tests
+                     , Duckling.Ordinal.JA.Tests
+                     , Duckling.Ordinal.KO.Tests
+                     , Duckling.Ordinal.NB.Tests
+                     , Duckling.Ordinal.NL.Tests
+                     , Duckling.Ordinal.PL.Tests
+                     , Duckling.Ordinal.PT.Tests
+                     , Duckling.Ordinal.RO.Tests
+                     , Duckling.Ordinal.RU.Tests
+                     , Duckling.Ordinal.SV.Tests
+                     , Duckling.Ordinal.TR.Tests
+                     , Duckling.Ordinal.UK.Tests
+                     , Duckling.Ordinal.VI.Tests
+                     , Duckling.Ordinal.ZH.Tests
+                     , Duckling.Ordinal.Tests
+
+                     -- PhoneNumber
+                     , Duckling.PhoneNumber.PT.Tests
+                     , Duckling.PhoneNumber.Tests
+
+                     -- Quantity
+                     , Duckling.Quantity.AR.Tests
+                     , Duckling.Quantity.EN.Tests
+                     , Duckling.Quantity.FR.Tests
+                     , Duckling.Quantity.HR.Tests
+                     , Duckling.Quantity.KO.Tests
+                     , Duckling.Quantity.PT.Tests
+                     , Duckling.Quantity.RO.Tests
+                     , Duckling.Quantity.RU.Tests
+                     , Duckling.Quantity.ZH.Tests
+                     , Duckling.Quantity.Tests
+
+                     -- Temperature
+                     , Duckling.Temperature.AR.Tests
+                     , Duckling.Temperature.EN.Tests
+                     , Duckling.Temperature.ES.Tests
+                     , Duckling.Temperature.FR.Tests
+                     , Duckling.Temperature.GA.Tests
+                     , Duckling.Temperature.HR.Tests
+                     , Duckling.Temperature.IT.Tests
+                     , Duckling.Temperature.JA.Tests
+                     , Duckling.Temperature.KO.Tests
+                     , Duckling.Temperature.PT.Tests
+                     , Duckling.Temperature.RO.Tests
+                     , Duckling.Temperature.TR.Tests
+                     , Duckling.Temperature.ZH.Tests
+                     , Duckling.Temperature.Tests
+
+                     -- Time
+                     , Duckling.Time.AR.Tests
+                     , Duckling.Time.DA.Tests
+                     , Duckling.Time.DE.Tests
+                     , Duckling.Time.EL.Tests
+                     , Duckling.Time.EN.Tests
+                     , Duckling.Time.ES.Tests
+                     , Duckling.Time.FR.Tests
+                     , Duckling.Time.GA.Tests
+                     , Duckling.Time.HR.Tests
+                     , Duckling.Time.HE.Tests
+                     , Duckling.Time.HU.Tests
+                     , Duckling.Time.IT.Tests
+                     , Duckling.Time.KO.Tests
+                     , Duckling.Time.NB.Tests
+                     , Duckling.Time.NL.Tests
+                     , Duckling.Time.PL.Tests
+                     , Duckling.Time.PT.Tests
+                     , Duckling.Time.RO.Tests
+                     , Duckling.Time.SV.Tests
+                     , Duckling.Time.VI.Tests
+                     , Duckling.Time.ZH.Tests
+                     , Duckling.Time.Tests
+
+                     -- Url
+                     , Duckling.Url.Tests
+
+                     -- Volume
+                     , Duckling.Volume.AR.Tests
+                     , Duckling.Volume.EN.Tests
+                     , Duckling.Volume.ES.Tests
+                     , Duckling.Volume.FR.Tests
+                     , Duckling.Volume.GA.Tests
+                     , Duckling.Volume.HR.Tests
+                     , Duckling.Volume.IT.Tests
+                     , Duckling.Volume.KO.Tests
+                     , Duckling.Volume.PT.Tests
+                     , Duckling.Volume.NL.Tests
+                     , Duckling.Volume.RO.Tests
+                     , Duckling.Volume.RU.Tests
+                     , Duckling.Volume.TR.Tests
+                     , Duckling.Volume.Tests
+
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wincomplete-patterns
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+executable duckling-regen-exe
+  main-is:             RegenMain.hs
+  hs-source-dirs:      exe
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wincomplete-patterns
+  other-modules:       Duckling.Ranking.Train
+                     , Duckling.Ranking.Generate
+  build-depends:       duckling
+                     , base
+                     , haskell-src-exts      >= 1.18 && < 1.20
+                     , text
+                     , unordered-containers
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+  if impl(eta)
+    -- Due to haskell-src-exts
+    buildable: False
+
+executable duckling-example-exe
+  main-is:             ExampleMain.hs
+  hs-source-dirs:      exe
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  other-modules:       Duckling.Data.TimeZone
+  build-depends:       duckling
+                     , base
+                     , aeson
+                     , bytestring
+                     , directory             >= 1.2.2.0 && < 1.4
+                     , extra
+                     , filepath              >= 1.4.0.0 && < 1.5
+                     , snap-core             >= 1.0.2.0 && < 1.1
+                     , snap-server           >= 1.0.1.1 && < 1.1
+                     , text
+                     , text-show
+                     , time
+                     , timezone-olson        >= 0.1.7 && < 0.2
+                     , timezone-series
+                     , unordered-containers
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+  if impl(eta)
+    buildable: False
+executable custom-dimension-example
+  main-is:             CustomDimensionExample.hs
+  hs-source-dirs:      exe
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       duckling
+                     , aeson
+                     , base
+                     , deepseq
+                     , dependent-sum
+                     , hashable
+                     , text
+                     , text-show
+                     , unordered-containers
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+executable duckling-request-sample
+  main-is:             DucklingRequestSample.hs
+  hs-source-dirs:      exe
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  other-modules:       Duckling.Data.TimeZone
+  build-depends:       duckling
+                     , base
+                     , dependent-sum
+                     , directory             >= 1.2.2.0 && < 1.4
+                     , extra
+                     , filepath              >= 1.4.0.0 && < 1.5
+                     , text
+                     , time
+                     , timezone-olson        >= 0.1.7 && < 0.2
+                     , timezone-series
+                     , unordered-containers
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+executable duckling-expensive
+  main-is:             DucklingExpensive.hs
+  hs-source-dirs:      exe
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  other-modules:       Duckling.Data.TimeZone
+  build-depends:       duckling
+                     , base
+                     , dependent-sum
+                     , directory             >= 1.2.2.0 && < 1.4
+                     , extra
+                     , filepath              >= 1.4.0.0 && < 1.5
+                     , text
+                     , time
+                     , timezone-olson        >= 0.1.7 && < 0.2
+                     , timezone-series
+                     , unordered-containers
+  default-language:    Haskell2010
+  default-extensions:  OverloadedStrings
+
+source-repository head
+  type:     git
+  location: https://github.com/facebook/duckling

--- a/patches/duckling-0.1.6.1.patch
+++ b/patches/duckling-0.1.6.1.patch
@@ -1,0 +1,122 @@
+From 81869bb5f0dd87b12c73e0c6090f0dfbd339aa3b Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 14:58:16 +0200
+Subject: [PATCH] Patched
+
+---
+ Duckling/Time/FR/Rules.hs | 12 ++++++------
+ Duckling/Time/PT/Rules.hs | 10 +++++-----
+ duckling.cabal            | 10 +++++++---
+ 3 files changed, 18 insertions(+), 14 deletions(-)
+
+diff --git a/Duckling/Time/FR/Rules.hs b/Duckling/Time/FR/Rules.hs
+index e009f3a..4e310ad 100644
+--- a/Duckling/Time/FR/Rules.hs
++++ b/Duckling/Time/FR/Rules.hs
+@@ -768,8 +768,8 @@ ruleEnSemaine = Rule
+       interval TTime.Open (dayOfWeek 1) (dayOfWeek 5)
+   }
+ 
+-ruleDdmm :: Rule
+-ruleDdmm = Rule
++ruleDdMmSlash :: Rule
++ruleDdMmSlash = Rule
+   { name = "dd/-mm"
+   , pattern =
+     [ regex "(3[01]|[12]\\d|0?[1-9])[/-](1[0-2]|0?[1-9])"
+@@ -1646,8 +1646,8 @@ ruleMaintenant = Rule
+   , prod = \_ -> tt $ cycleNth TG.Second 0
+   }
+ 
+-ruleDdmmyyyy :: Rule
+-ruleDdmmyyyy = Rule
++ruleDdMmYyyySlash :: Rule
++ruleDdMmYyyySlash = Rule
+   { name = "dd/-mm/-yyyy"
+   , pattern =
+     [ regex "(3[01]|[12]\\d|0?[1-9])[/-](1[0-2]|0?[1-9])[-/](\\d{2,4})"
+@@ -1960,8 +1960,8 @@ rules =
+   , ruleDdMm
+   , ruleDdMmYyyy
+   , ruleDdddMonthinterval
+-  , ruleDdmm
+-  , ruleDdmmyyyy
++  , ruleDdMmSlash
++  , ruleDdMmYyyySlash
+   , ruleDeDatetimeDatetimeInterval
+   , ruleDeTimeofdayTimeofdayInterval
+   , ruleDemain
+diff --git a/Duckling/Time/PT/Rules.hs b/Duckling/Time/PT/Rules.hs
+index 8f4dca2..cba33b7 100644
+--- a/Duckling/Time/PT/Rules.hs
++++ b/Duckling/Time/PT/Rules.hs
+@@ -26,8 +26,8 @@ import Duckling.Types
+ import qualified Duckling.Time.Types as TTime
+ import qualified Duckling.TimeGrain.Types as TG
+ 
+-ruleSHourmintimeofday :: Rule
+-ruleSHourmintimeofday = Rule
++ruleSHourminTimeofday :: Rule
++ruleSHourminTimeofday = Rule
+   { name = "às <hour-min>(time-of-day)"
+   , pattern =
+     [ regex "(à|a)s?"
+@@ -223,8 +223,8 @@ ruleEsteCycle = Rule
+       _ -> Nothing
+   }
+ 
+-ruleSHourminTimeofday :: Rule
+-ruleSHourminTimeofday = Rule
++ruleSHourminIsnotlatentTimeofday :: Rule
++ruleSHourminIsnotlatentTimeofday = Rule
+   { name = "às <hour-min> <time-of-day>"
+   , pattern =
+     [ regex "(à|a)s"
+@@ -1463,7 +1463,7 @@ rules =
+   , ruleProximasNCycle
+   , ruleRightNow
+   , ruleSHourminTimeofday
+-  , ruleSHourmintimeofday
++  , ruleSHourminIsnotlatentTimeofday
+   , ruleSTimeofday
+   , ruleSeason
+   , ruleSeason2
+diff --git a/duckling.cabal b/duckling.cabal
+index cdebf84..e2a6aee 100644
+--- a/duckling.cabal
++++ b/duckling.cabal
+@@ -679,9 +679,9 @@ library
+                      , extra                 >= 1.4.10 && < 1.7
+                      , hashable              >= 1.2.4.0 && < 1.3
+                      , regex-base            >= 0.93.2 && < 0.94
+-                     , regex-pcre            >= 0.94.4 && < 0.95
++                     , regex-pcre-builtin    >= 0.94.4 && < 0.95
+                      , text                  >= 1.2.2.1 && < 1.3
+-                     , text-show             >= 2.1.2 && < 3.7
++                     , text-show             >= 2.1.2 && < 3.9
+                      , time                  >= 1.5.0.1 && < 1.9
+                      , timezone-series       >= 0.1.5.1 && < 0.2
+                      , unordered-containers  >= 0.2.7.2 && < 0.3
+@@ -937,6 +937,9 @@ executable duckling-regen-exe
+                      , unordered-containers
+   default-language:    Haskell2010
+   default-extensions:  OverloadedStrings
++  if impl(eta)
++    -- Due to haskell-src-exts
++    buildable: False
+ 
+ executable duckling-example-exe
+   main-is:             ExampleMain.hs
+@@ -960,7 +963,8 @@ executable duckling-example-exe
+                      , unordered-containers
+   default-language:    Haskell2010
+   default-extensions:  OverloadedStrings
+-
++  if impl(eta)
++    buildable: False
+ executable custom-dimension-example
+   main-is:             CustomDimensionExample.hs
+   hs-source-dirs:      exe
+-- 
+2.16.2.windows.1
+

--- a/patches/text-show-3.8.2.cabal
+++ b/patches/text-show-3.8.2.cabal
@@ -1,0 +1,396 @@
+name:                text-show
+version:             3.8.2
+synopsis:            Efficient conversion of values into Text
+description:         @text-show@ offers a replacement for the @Show@ typeclass intended
+                     for use with @Text@ instead of @String@s. This package was created
+                     in the spirit of
+                     @<http://hackage.haskell.org/package/bytestring-show bytestring-show>@.
+                     .
+                     At the moment, @text-show@ provides instances for most data
+                     types in the @<http://hackage.haskell.org/package/array array>@,
+                     @<http://hackage.haskell.org/package/base base>@,
+                     @<http://hackage.haskell.org/package/bytestring bytestring>@, and
+                     @<http://hackage.haskell.org/package/text text>@ packages.
+                     Therefore, much of the source code for @text-show@ consists of
+                     borrowed code from those packages in order to ensure that the
+                     behaviors of @Show@ and @TextShow@ coincide.
+                     .
+                     For most uses, simply importing "TextShow"
+                     will suffice:
+                     .
+                     @
+                        module Main where
+                        .
+                        import TextShow
+                        .
+                        main :: IO ()
+                        main = printT (Just \"Hello, World!\")
+                     @
+                     .
+                     See also the
+                     <https://github.com/RyanGlScott/text-show/wiki/Naming-conventions naming conventions>
+                     page.
+                     .
+                     Support for automatically deriving @TextShow@ instances can be found
+                     in the "TextShow.TH" and "TextShow.Generic" modules.
+homepage:            https://github.com/RyanGlScott/text-show
+bug-reports:         https://github.com/RyanGlScott/text-show/issues
+license:             BSD3
+license-file:        LICENSE
+author:              Ryan Scott
+maintainer:          Ryan Scott <ryan.gl.scott@gmail.com>
+stability:           Provisional
+copyright:           (C) 2014-2017 Ryan Scott
+category:            Text
+build-type:          Simple
+tested-with:         GHC == 7.4.2
+                   , GHC == 7.6.3
+                   , GHC == 7.8.4
+                   , GHC == 7.10.3
+                   , GHC == 8.0.2
+                   , GHC == 8.2.2
+                   , GHC == 8.4.4
+                   , GHC == 8.6.5
+                   , GHC == 8.8.1
+extra-source-files:  CHANGELOG.md, README.md, include/*.h
+cabal-version:       >=1.10
+
+source-repository head
+  type:                git
+  location:            https://github.com/RyanGlScott/text-show
+
+flag base-4-9
+  description:         Use base-4.9 or later.
+  default:             True
+
+flag template-haskell-2-11
+  description:         Use template-haskell-2.11.0.0 or later.
+  default:             True
+
+flag new-functor-classes
+  description:         Use a version of transformers or transformers-compat with a
+                       modern-style Data.Functor.Classes module. This flag cannot be
+                       used when building with transformers-0.4, since it comes with
+                       a different version of Data.Functor.Classes.
+  default:             True
+
+library
+  exposed-modules:     TextShow
+                       TextShow.Control.Applicative
+                       TextShow.Control.Concurrent
+                       TextShow.Control.Exception
+                       TextShow.Control.Monad.ST
+                       TextShow.Data.Array
+                       TextShow.Data.Bool
+                       TextShow.Data.ByteString
+                       TextShow.Data.Char
+                       TextShow.Data.Complex
+                       TextShow.Data.Data
+                       TextShow.Data.Dynamic
+                       TextShow.Data.Either
+                       TextShow.Data.Fixed
+                       TextShow.Data.Floating
+                       TextShow.Data.Functor.Compose
+                       TextShow.Data.Functor.Identity
+                       TextShow.Data.Functor.Product
+                       TextShow.Data.Functor.Sum
+                       TextShow.Debug.Trace
+                       TextShow.Debug.Trace.Generic
+                       TextShow.Debug.Trace.TH
+                       TextShow.Generic
+                       TextShow.Data.Integral
+                       TextShow.Data.List
+                       TextShow.Data.List.NonEmpty
+                       TextShow.Data.Maybe
+                       TextShow.Data.Monoid
+                       TextShow.Data.Ord
+                       TextShow.Data.Proxy
+                       TextShow.Data.Ratio
+                       TextShow.Data.Semigroup
+                       TextShow.Data.Text
+                       TextShow.Data.Tuple
+                       TextShow.Data.Typeable
+                       TextShow.Data.Version
+                       TextShow.Data.Void
+                       TextShow.Foreign.C.Types
+                       TextShow.Foreign.Ptr
+                       TextShow.Functions
+                       TextShow.GHC.Fingerprint
+                       TextShow.GHC.Generics
+                       TextShow.GHC.Stats
+                       TextShow.Numeric.Natural
+                       TextShow.System.Exit
+                       TextShow.System.IO
+                       TextShow.System.Posix.Types
+                       TextShow.Text.Read
+                       TextShow.TH
+
+                       -- Only exports functions if using Windows
+                       TextShow.GHC.Conc.Windows
+                       -- Only exports functions if not using Windows
+                       TextShow.GHC.Event
+
+                       -- Only exports functions if base >= 4.6
+                       TextShow.GHC.TypeLits
+
+                       -- Only exports functions if base >= 4.7
+                       TextShow.Data.Type.Coercion
+                       TextShow.Data.Type.Equality
+                       -- Only exports functions if base >= 4.7 && < 4.8
+                       TextShow.Data.OldTypeable
+
+                       -- Only exports functions if base >= 4.8
+                       TextShow.GHC.RTS.Flags
+                       TextShow.GHC.StaticPtr
+
+                       -- Only exports functions if base >= 4.8.1
+                       TextShow.GHC.Stack
+  other-modules:       TextShow.Classes
+                       TextShow.Data.Typeable.Utils
+                       TextShow.FromStringTextShow
+                       TextShow.Instances
+                       TextShow.Options
+                       TextShow.TH.Internal
+                       TextShow.TH.Names
+                       TextShow.Utils
+  build-depends:       array                 >= 0.3    && < 0.6
+                     , base-compat-batteries >= 0.10   && < 0.11
+                     , bifunctors            >= 5.1    && < 6
+                     , bytestring            >= 0.9    && < 0.11
+                     , bytestring-builder
+                     , containers            >= 0.1    && < 0.7
+                     , contravariant         >= 0.5    && < 2
+                     , generic-deriving      >= 1.11   && < 2
+                     , ghc-prim
+                     , nats                  >= 0.1    && < 2
+                     , semigroups            >= 0.17   && < 1
+                     , tagged                >= 0.4.4  && < 1
+                     , text                  >= 0.11.1 && < 1.3
+                     , th-abstraction        >= 0.2.2  && < 0.4
+                     , th-lift               >= 0.7.6  && < 1
+                     , void                  >= 0.5    && < 1
+
+  if flag(base-4-9)
+    build-depends:     base                  >= 4.9 && < 4.14
+    cpp-options:       "-DNEW_FUNCTOR_CLASSES"
+  else
+    build-depends:     base                  >= 4.5 && < 4.9
+
+  if flag(template-haskell-2-11)
+    build-depends:     template-haskell      >= 2.11 && < 2.16
+                     , ghc-boot-th           >= 8.0  && < 8.9
+  else
+    build-depends:     template-haskell      >= 2.5  && < 2.11
+
+  if flag(new-functor-classes)
+    build-depends:     transformers          (>= 0.2.1 && < 0.4) || (>= 0.5 && < 0.6)
+                     , transformers-compat   >= 0.5 && < 1
+    cpp-options:       "-DNEW_FUNCTOR_CLASSES"
+  else
+    build-depends:     transformers          == 0.4.*
+
+  if impl(eta)
+    build-depends:     integer
+  else
+    build-depends:     integer-gmp
+    
+  hs-source-dirs:      src, shared
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+  include-dirs:        include
+  includes:            generic.h
+
+test-suite spec
+  type:                exitcode-stdio-1.0
+  main-is:             Spec.hs
+  other-modules:       Derived.DataFamilies
+                       Derived.DatatypeContexts
+                       Derived.ExistentialQuantification
+                       Derived.Infix
+                       Derived.MagicHash
+                       Derived.PolyKinds
+                       Derived.RankNTypes
+                       Derived.Records
+                       Derived.TypeSynonyms
+
+                       Instances.Control.Concurrent
+                       Instances.Control.Exception
+                       Instances.Control.Monad.ST
+                       Instances.Data.Char
+                       Instances.Data.Data
+                       Instances.Data.Dynamic
+                       Instances.Data.Floating
+                       Instances.Data.Ord
+                       Instances.Data.Semigroup
+                       Instances.Data.Text
+                       Instances.Data.Tuple
+                       Instances.Data.Typeable
+                       Instances.Foreign.C.Types
+                       Instances.Foreign.Ptr
+                       Instances.FromStringTextShow
+                       Instances.Generic
+                       Instances.GHC.Fingerprint
+                       Instances.GHC.Generics
+                       Instances.GHC.Stats
+                       Instances.Options
+                       Instances.System.IO
+                       Instances.System.Posix.Types
+                       Instances.Text.Read
+                       Instances.Utils
+                       Instances.Utils.GenericArbitrary
+
+                       -- Only exports instances if using Windows
+                       Instances.GHC.Conc.Windows
+                       -- Only exports instances if not using Windows
+                       Instances.GHC.Event
+
+                       -- Only exports instances if base >= 4.6
+                       Instances.GHC.TypeLits
+
+                       -- Only exports instances if base >= 4.7
+                       Instances.Data.Type.Coercion
+                       Instances.Data.Type.Equality
+                       -- Only exports instances if base >= 4.7 && < 4.8
+                       Instances.Data.OldTypeable
+
+                       -- Only exports instances if base >= 4.8
+                       Instances.GHC.RTS.Flags
+                       Instances.GHC.StaticPtr
+
+                       -- Only exports instances if base >= 4.9
+                       Instances.GHC.Stack
+
+                       -- Only exports instances if base >= 4.12
+                       Instances.Data.Monoid
+
+                       Spec.BuilderSpec
+                       Spec.Control.ApplicativeSpec
+                       Spec.Control.ConcurrentSpec
+                       Spec.Control.ExceptionSpec
+                       Spec.Control.Monad.STSpec
+                       Spec.Data.ArraySpec
+                       Spec.Data.BoolSpec
+                       Spec.Data.ByteStringSpec
+                       Spec.Data.CharSpec
+                       Spec.Data.ComplexSpec
+                       Spec.Data.DataSpec
+                       Spec.Data.DynamicSpec
+                       Spec.Data.EitherSpec
+                       Spec.Data.FixedSpec
+                       Spec.Data.FloatingSpec
+                       Spec.Data.Functor.ComposeSpec
+                       Spec.Data.Functor.IdentitySpec
+                       Spec.Data.Functor.ProductSpec
+                       Spec.Data.Functor.SumSpec
+                       Spec.Data.IntegralSpec
+                       Spec.Data.ListSpec
+                       Spec.Data.List.NonEmptySpec
+                       Spec.Data.MaybeSpec
+                       Spec.Data.MonoidSpec
+                       Spec.Data.OrdSpec
+                       Spec.Data.ProxySpec
+                       Spec.Data.RatioSpec
+                       Spec.Data.SemigroupSpec
+                       Spec.Data.TextSpec
+                       Spec.Data.TupleSpec
+                       Spec.Data.TypeableSpec
+                       Spec.Data.VersionSpec
+                       Spec.Derived.DataFamiliesSpec
+                       Spec.Derived.DatatypeContextsSpec
+                       Spec.Derived.ExistentialQuantificationSpec
+                       Spec.Derived.InfixSpec
+                       Spec.Derived.MagicHashSpec
+                       Spec.Derived.PolyKindsSpec
+                       Spec.Derived.RankNTypesSpec
+                       Spec.Derived.RecordsSpec
+                       Spec.Derived.TypeSynonymsSpec
+                       Spec.Foreign.C.TypesSpec
+                       Spec.Foreign.PtrSpec
+                       Spec.FromStringTextShowSpec
+                       Spec.FunctionsSpec
+                       Spec.GenericSpec
+                       Spec.GHC.FingerprintSpec
+                       Spec.GHC.GenericsSpec
+                       Spec.GHC.StatsSpec
+                       Spec.Numeric.NaturalSpec
+                       Spec.OptionsSpec
+                       Spec.System.ExitSpec
+                       Spec.System.IOSpec
+                       Spec.System.Posix.TypesSpec
+                       Spec.Text.ReadSpec
+                       Spec.Utils
+
+                       -- Only exports tests if using Windows
+                       Spec.GHC.Conc.WindowsSpec
+                       -- Only exports tests if not using Windows
+                       Spec.GHC.EventSpec
+
+                       -- Only exports tests if base >= 4.6
+                       Spec.GHC.TypeLitsSpec
+
+                       -- Only exports tests if base >= 4.7
+                       Spec.Data.Type.CoercionSpec
+                       Spec.Data.Type.EqualitySpec
+                       -- Only exports tests if base >= 4.7 && < 4.8
+                       Spec.Data.OldTypeableSpec
+
+                       -- Only exports tests if base >= 4.8
+                       Spec.GHC.RTS.FlagsSpec
+                       Spec.GHC.StaticPtrSpec
+
+                       -- Only exports tests if base >= 4.9
+                       Spec.GHC.StackSpec
+
+                       TextShow.TH.Names
+  build-depends:       array                 >= 0.3    && < 0.6
+                     , base-compat-batteries >= 0.10   && < 0.11
+                     , base-orphans          >= 0.6    && < 0.9
+                     , bytestring            >= 0.9    && < 0.11
+                     , bytestring-builder
+                     , deriving-compat       >= 0.5.6  && < 1
+                     , generic-deriving      >= 1.11   && < 2
+                     , ghc-prim
+                     , hspec                 >= 2      && < 3
+                     , nats                  >= 0.1    && < 2
+                     , QuickCheck            >= 2.12   && < 2.14
+                     , quickcheck-instances  >= 0.3.18 && < 0.3.21
+                     , semigroups            >= 0.18.3 && < 1
+                     , tagged                >= 0.8.3  && < 1
+                     , template-haskell      >= 2.5    && < 2.16
+                     , text                  >= 0.11.1 && < 1.3
+                     , text-show
+                     , transformers-compat   >= 0.5    && < 1
+  build-tool-depends:  hspec-discover:hspec-discover
+
+  if flag(base-4-9)
+    build-depends:     base                  >= 4.9 && < 4.14
+    cpp-options:       "-DNEW_FUNCTOR_CLASSES"
+  else
+    build-depends:     base                  >= 4.5 && < 4.9
+
+  if flag(new-functor-classes)
+    build-depends:     transformers          (>= 0.2.1 && < 0.4) || (>= 0.5 && < 0.6)
+    cpp-options:       "-DNEW_FUNCTOR_CLASSES"
+  else
+    build-depends:     transformers          == 0.4.*
+
+  hs-source-dirs:      tests, shared
+  default-language:    Haskell2010
+  ghc-options:         -Wall -threaded -rtsopts
+  include-dirs:        include
+  includes:            generic.h
+                     , overlap.h
+
+benchmark bench
+  type:                exitcode-stdio-1.0
+  main-is:             Bench.hs
+  build-depends:       base      >= 4.5    && < 4.14
+                     , criterion >= 1.1.4  && < 2
+                     , deepseq   >= 1.3    && < 2
+                     , ghc-prim
+                     , text-show
+                     , text      >= 0.11.1 && < 1.3
+
+  hs-source-dirs:      benchmarks
+  default-language:    Haskell2010
+  ghc-options:         -Wall

--- a/patches/text-show-3.8.2.patch
+++ b/patches/text-show-3.8.2.patch
@@ -1,0 +1,436 @@
+From 67e632f1f9c7c793fbb31eeefc84d88de7b20949 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Wed, 22 May 2019 11:29:29 +0200
+Subject: [PATCH] Patched
+
+---
+ shared/TextShow/TH/Names.hs        |  6 +++---
+ src/TextShow/Control/Concurrent.hs | 10 ++++++++++
+ src/TextShow/Data/Type/Equality.hs |  4 ++--
+ src/TextShow/Data/Typeable.hs      | 29 +++++++++++++++++++----------
+ src/TextShow/Debug/Trace.hs        | 16 ++++++++++++++--
+ src/TextShow/GHC/Event.hs          |  6 +++---
+ src/TextShow/GHC/Generics.hs       |  2 +-
+ src/TextShow/GHC/RTS/Flags.hs      |  3 +--
+ src/TextShow/Generic.hs            |  6 +++---
+ src/TextShow/Numeric/Natural.hs    |  6 +++++-
+ src/TextShow/System/Posix/Types.hs |  2 ++
+ text-show.cabal                    |  8 ++++++--
+ 12 files changed, 69 insertions(+), 29 deletions(-)
+
+diff --git a/shared/TextShow/TH/Names.hs b/shared/TextShow/TH/Names.hs
+index 1f23bfa..2620d9b 100644
+--- a/shared/TextShow/TH/Names.hs
++++ b/shared/TextShow/TH/Names.hs
+@@ -20,7 +20,7 @@ module TextShow.TH.Names (
+ #if MIN_VERSION_base(4,6,0)
+     numberTypeName,
+ #endif
+-#if MIN_VERSION_base(4,8,0)
++#if MIN_VERSION_base(4,8,0) && !defined(TOOL_VERSION_eta)
+     giveGCStatsTypeName,
+     doCostCentresTypeName,
+     doHeapProfileTypeName,
+@@ -34,7 +34,7 @@ import Language.Haskell.TH.Syntax
+ import Text.Read.Lex (Number)
+ #endif
+ 
+-#if MIN_VERSION_base(4,8,2)
++#if MIN_VERSION_base(4,8,2)  && !defined(TOOL_VERSION_eta)
+ import GHC.RTS.Flags (GiveGCStats, DoCostCentres, DoHeapProfile, DoTrace)
+ #endif
+ 
+@@ -78,7 +78,7 @@ numberTypeName = mkNameG_tc "base" "Text.Read.Lex" "Number"
+ # endif
+ #endif
+ 
+-#if MIN_VERSION_base(4,8,0)
++#if MIN_VERSION_base(4,8,0)  && !defined(TOOL_VERSION_eta)
+ -- | The 'Name' of 'GiveGCStats'.
+ giveGCStatsTypeName :: Name
+ # if MIN_VERSION_base(4,8,2)
+diff --git a/src/TextShow/Control/Concurrent.hs b/src/TextShow/Control/Concurrent.hs
+index 52bdee6..f54fba2 100644
+--- a/src/TextShow/Control/Concurrent.hs
++++ b/src/TextShow/Control/Concurrent.hs
+@@ -2,6 +2,7 @@
+ {-# LANGUAGE MagicHash                #-}
+ {-# LANGUAGE TemplateHaskell          #-}
+ {-# LANGUAGE UnliftedFFITypes         #-}
++{-# LANGUAGE CPP                      #-}
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+ {-|
+ Module:      TextShow.Control.Concurrent
+@@ -37,11 +38,20 @@ instance TextShow ThreadId where
+     showbPrec p t = fromString "ThreadId " <> showbPrec p (getThreadId t)
+     {-# INLINE showbPrec #-}
+ 
++#if !defined(TOOL_VERSION_eta)
+ -- Temporary workaround until Trac #8281 is fixed
+ foreign import ccall unsafe "rts_getThreadId" getThreadId# :: Addr# -> CInt
+ 
+ getThreadId :: ThreadId -> CInt
+ getThreadId (ThreadId tid) = getThreadId# (unsafeCoerce# tid)
++#else
++foreign import java unsafe "@static eta.runtime.stg.TSO.getThreadId"
++  getThreadId# :: ThreadId# -> CInt
++
++getThreadId :: ThreadId -> CInt
++getThreadId (ThreadId tid) = getThreadId# tid
++#endif
++
+ 
+ -- | /Since: 2/
+ $(deriveTextShow ''ThreadStatus)
+diff --git a/src/TextShow/Data/Type/Equality.hs b/src/TextShow/Data/Type/Equality.hs
+index 420f924..e072d31 100644
+--- a/src/TextShow/Data/Type/Equality.hs
++++ b/src/TextShow/Data/Type/Equality.hs
+@@ -24,7 +24,7 @@ module TextShow.Data.Type.Equality () where
+ 
+ #if MIN_VERSION_base(4,7,0)
+ import Data.Type.Equality ((:~:))
+-# if MIN_VERSION_base(4,10,0)
++# if MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta)
+ import Data.Type.Equality ((:~~:))
+ # endif
+ 
+@@ -41,7 +41,7 @@ instance TextShow1 ((:~:) a) where
+ -- | /Since: 2/
+ $(deriveTextShow2 ''(:~:))
+ 
+-# if MIN_VERSION_base(4,10,0)
++# if MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta)
+ -- | /Since: 3.6/
+ $(deriveTextShow ''(:~~:))
+ 
+diff --git a/src/TextShow/Data/Typeable.hs b/src/TextShow/Data/Typeable.hs
+index 33e427a..a411267 100644
+--- a/src/TextShow/Data/Typeable.hs
++++ b/src/TextShow/Data/Typeable.hs
+@@ -10,7 +10,9 @@
+ 
+ #if __GLASGOW_HASKELL__ >= 801
+ {-# LANGUAGE PatternSynonyms   #-}
++# if !defined(TOOL_VERSION_eta)
+ {-# LANGUAGE TypeApplications  #-}
++# endif
+ #endif
+ 
+ {-# OPTIONS_GHC -fno-warn-orphans #-}
+@@ -32,7 +34,7 @@ module TextShow.Data.Typeable () where
+ import           Prelude ()
+ import           Prelude.Compat
+ 
+-#if MIN_VERSION_base(4,10,0)
++#if MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta)
+ import           Data.Kind (Type)
+ import           Data.Text.Lazy.Builder (Builder, fromString, singleton)
+ import           Data.Type.Equality ((:~~:)(..))
+@@ -52,14 +54,16 @@ import           Type.Reflection (pattern App, pattern Con, pattern Con', patter
+ import           Data.Text.Lazy.Builder (fromString, singleton)
+ import           Data.Typeable (TypeRep, typeRepArgs, typeRepTyCon)
+ import           Data.Typeable.Internal (tyConName)
+-# if MIN_VERSION_base(4,8,0)
++# if MIN_VERSION_base(4,8,0) 
+ import           Data.Typeable.Internal (typeRepKinds)
+ # endif
+ # if MIN_VERSION_base(4,9,0)
+ import           Data.Text.Lazy.Builder (Builder)
+ import           Data.Typeable.Internal (Proxy(..), Typeable,
+                                          TypeRep(TypeRep), typeRep)
++# if !defined(TOOL_VERSION_eta)
+ import           GHC.Exts (RuntimeRep(..), TYPE)
++# endif
+ # else
+ import           Data.Typeable.Internal (funTc, listTc)
+ # endif
+@@ -67,7 +71,11 @@ import           Data.Typeable.Internal (funTc, listTc)
+ # if MIN_VERSION_base(4,9,0)
+ import           GHC.Exts (Char(..))
+ import           GHC.Prim (Addr#, (+#), eqChar#, indexCharOffAddr#)
++#  if !defined(TOOL_VERSION_eta)
+ import           GHC.Types (TyCon(..), TrName(..), Module(..), isTrue#)
++#  else
++import           GHC.Types (isTrue#)
++import           Data.Typeable.Internal (TyCon)
+ # else
+ import           Data.Typeable.Internal (TyCon)
+ # endif
+@@ -78,7 +86,7 @@ import           TextShow.Data.Typeable.Utils (showbArgs, showbTuple)
+ import           TextShow.Utils (isTupleString)
+ #endif
+ 
+-#if !(MIN_VERSION_base(4,10,0))
++#if !(MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta))
+ # if MIN_VERSION_base(4,9,0)
+ tyConOf :: Typeable a => Proxy a -> TyCon
+ tyConOf = typeRepTyCon . typeRep
+@@ -88,7 +96,7 @@ tcFun = tyConOf (Proxy :: Proxy (Int -> Int))
+ 
+ tcList :: TyCon
+ tcList = tyConOf (Proxy :: Proxy [])
+-
++#  if !defined(TOOL_VERSION_eta)
+ tcTYPE :: TyCon
+ tcTYPE = tyConOf (Proxy :: Proxy TYPE)
+ 
+@@ -97,6 +105,7 @@ tc'Lifted = tyConOf (Proxy :: Proxy 'PtrRepLifted)
+ 
+ tc'Unlifted :: TyCon
+ tc'Unlifted = tyConOf (Proxy :: Proxy 'PtrRepUnlifted)
++#  endif
+ # else
+ -- | The list 'TyCon'.
+ tcList :: TyCon
+@@ -113,7 +122,7 @@ isTupleTyCon :: TyCon -> Bool
+ isTupleTyCon = isTupleString . tyConName
+ {-# INLINE isTupleTyCon #-}
+ 
+-#if MIN_VERSION_base(4,10,0)
++#if MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta)
+ -- | Only available with @base-4.10.0.0@ or later.
+ --
+ -- /Since: 3.6/
+@@ -180,13 +189,13 @@ instance TextShow TypeRep where
+     showbPrec p tyrep =
+         case tys of
+           [] -> showb tycon
+-# if MIN_VERSION_base(4,9,0)
++# if MIN_VERSION_base(4,9,0) && !defined(TOOL_VERSION_eta)
+           [x@(TypeRep _ argCon _ _)]
+ # else
+           [x]
+ # endif
+             | tycon == tcList -> singleton '[' <> showb x <> singleton ']'
+-# if MIN_VERSION_base(4,9,0)
++# if MIN_VERSION_base(4,9,0) && !defined(TOOL_VERSION_eta)
+             | tycon == tcTYPE && argCon == tc'Lifted   -> singleton '*'
+             | tycon == tcTYPE && argCon == tc'Unlifted -> singleton '#'
+ # endif
+@@ -214,15 +223,15 @@ instance TextShow TypeRep where
+ 
+ -- | /Since: 2/
+ instance TextShow TyCon where
+-#if MIN_VERSION_base(4,10,0)
++#if MIN_VERSION_base(4,10,0) && !defined(TOOL_VERSION_eta)
+     showbPrec p (TyCon _ _ _ tc_name _ _) = showbPrec p tc_name
+-#elif MIN_VERSION_base(4,9,0)
++#elif MIN_VERSION_base(4,9,0) && !defined(TOOL_VERSION_eta)
+     showb (TyCon _ _ _ tc_name) = showb tc_name
+ #else
+     showb = fromString . tyConName
+ #endif
+ 
+-#if MIN_VERSION_base(4,9,0)
++#if MIN_VERSION_base(4,9,0)  && !defined(TOOL_VERSION_eta)
+ -- | Only available with @base-4.9.0.0@ or later.
+ --
+ -- /Since: 3/
+diff --git a/src/TextShow/Debug/Trace.hs b/src/TextShow/Debug/Trace.hs
+index dbf49ba..c3f52d9 100644
+--- a/src/TextShow/Debug/Trace.hs
++++ b/src/TextShow/Debug/Trace.hs
+@@ -69,7 +69,9 @@ import           Data.Text.Lazy (toStrict)
+ import           Debug.Trace
+ 
+ import           Foreign.C.String (CString)
+-
++#if defined(TOOL_VERSION_eta)
++import           Foreign.C.String (peekCString)
++#endif
+ import           GHC.Stack (currentCallStack, renderStack)
+ 
+ import           Prelude ()
+@@ -121,9 +123,19 @@ traceIOByteString msg = useAsCString "%s\n" $ \cfmt -> do
+ 
+ -- don't use debugBelch() directly, because we cannot call varargs functions
+ -- using the FFI.
++#if !defined(TOOL_VERSION_eta)
+ foreign import ccall unsafe "HsBase.h debugBelch2"
+     debugBelch :: CString -> CString -> IO ()
+-
++#else
++foreign import java unsafe "@static eta.base.Utils.debugBelch"
++  debugBelchStr :: String -> String -> IO ()
++
++debugBelch :: CString -> CString -> IO ()
++debugBelch cstr1 cstr2 = do
++  str1 <- peekCString cstr1
++  str2 <- peekCString cstr2
++  debugBelchStr str1 str2
++#endif
+ {-|
+ The 'tracet' function outputs the trace message given as its first argument,
+ before returning the second argument as its result.
+diff --git a/src/TextShow/GHC/Event.hs b/src/TextShow/GHC/Event.hs
+index 963e2e8..76dfc1a 100644
+--- a/src/TextShow/GHC/Event.hs
++++ b/src/TextShow/GHC/Event.hs
+@@ -20,7 +20,7 @@ Only provided if using a platform other than Windows or GHCJS.
+ -}
+ module TextShow.GHC.Event () where
+ 
+-#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS)
++#if !defined(__GHCJS__) && !defined(mingw32_HOST_OS) && !defined(TOOL_VERSION_eta)
+ import Data.List (intersperse)
+ import Data.Maybe (catMaybes)
+ import Data.Text.Lazy.Builder (Builder, singleton)
+@@ -39,7 +39,7 @@ import TextShow.TH.Internal (deriveTextShow)
+ import TextShow.TH.Names (evtCloseValName, eventIsValName,
+                           fdKeyTypeName, uniqueTypeName, asInt64ValName)
+ 
+-# if MIN_VERSION_base(4,8,1)
++# if MIN_VERSION_base(4,8,1) && !defined(TOOL_VERSION_eta)
+ import GHC.Event (Lifetime)
+ # endif
+ 
+@@ -62,7 +62,7 @@ instance TextShow $(conT uniqueTypeName) where
+     showb = showb . $(varE asInt64ValName)
+     {-# INLINE showb #-}
+ 
+-# if MIN_VERSION_base(4,8,1)
++# if MIN_VERSION_base(4,8,1) && !defined(TOOL_VERSION_eta)
+ -- | Only available with @base-4.8.1.0@ or later.
+ --
+ -- /Since: 2/
+diff --git a/src/TextShow/GHC/Generics.hs b/src/TextShow/GHC/Generics.hs
+index 9e5ed7e..65dbc8b 100644
+--- a/src/TextShow/GHC/Generics.hs
++++ b/src/TextShow/GHC/Generics.hs
+@@ -118,7 +118,7 @@ $(deriveTextShow1 'UWord)
+ $(deriveTextShow ''Fixity)
+ -- | /Since: 2/
+ $(deriveTextShow ''Associativity)
+-#if MIN_VERSION_base(4,9,0)
++#if MIN_VERSION_base(4,9,0) && !defined(TOOL_VERSION_eta)
+ -- | Only available with @base-4.9.0.0@ or later.
+ --
+ -- /Since: 3/
+diff --git a/src/TextShow/GHC/RTS/Flags.hs b/src/TextShow/GHC/RTS/Flags.hs
+index b4397d0..661b3f8 100644
+--- a/src/TextShow/GHC/RTS/Flags.hs
++++ b/src/TextShow/GHC/RTS/Flags.hs
+@@ -19,7 +19,7 @@ Only provided if using @base-4.8.0.0@ or later.
+ -}
+ module TextShow.GHC.RTS.Flags () where
+ 
+-#if MIN_VERSION_base(4,8,0)
++#if MIN_VERSION_base(4,8,0) && !defined(TOOL_VERSION_eta)
+ import GHC.RTS.Flags
+ 
+ import TextShow.Data.Bool     ()
+@@ -31,7 +31,6 @@ import TextShow.Data.Maybe    ()
+ import TextShow.TH.Internal (deriveTextShow)
+ import TextShow.TH.Names (giveGCStatsTypeName, doCostCentresTypeName,
+                           doHeapProfileTypeName, doTraceTypeName)
+-
+ -- | /Since: 2/
+ $(deriveTextShow ''RTSFlags)
+ -- | /Since: 2/
+diff --git a/src/TextShow/Generic.hs b/src/TextShow/Generic.hs
+index 66fbb83..178e47a 100644
+--- a/src/TextShow/Generic.hs
++++ b/src/TextShow/Generic.hs
+@@ -105,7 +105,7 @@ import qualified Data.Text.Lazy.Builder as TB (fromString, singleton)
+ import           Data.Text.Lazy.Builder (Builder)
+ 
+ import           Generics.Deriving.Base
+-#if !defined(__LANGUAGE_DERIVE_GENERIC1__)
++#if !defined(__LANGUAGE_DERIVE_GENERIC1__) && !defined(TOOL_VERSION_eta)
+ import qualified Generics.Deriving.TH as Generics
+ #endif
+ 
+@@ -231,7 +231,7 @@ newtype FromGeneric1 f a = FromGeneric1 { fromGeneric1 :: f a }
+ #if __GLASGOW_HASKELL__ >= 706
+            , Generic
+ #endif
+-#if defined(__LANGUAGE_DERIVE_GENERIC1__)
++#if defined(__LANGUAGE_DERIVE_GENERIC1__)  && !defined(TOOL_VERSION_eta)
+            , Generic1
+ #endif
+ #if __GLASGOW_HASKELL__ >= 800
+@@ -676,7 +676,7 @@ instance Lift (f a) => Lift (FromGeneric1 f a) where
+     lift = $(makeLift ''FromGeneric1)
+ #endif
+ 
+-#if !defined(__LANGUAGE_DERIVE_GENERIC1__)
++#if !defined(__LANGUAGE_DERIVE_GENERIC1__) && !defined(TOOL_VERSION_eta)
+ $(Generics.deriveMeta           ''FromGeneric1)
+ $(Generics.deriveRepresentable1 ''FromGeneric1)
+ #endif
+diff --git a/src/TextShow/Numeric/Natural.hs b/src/TextShow/Numeric/Natural.hs
+index 2d208a1..ce106b5 100644
+--- a/src/TextShow/Numeric/Natural.hs
++++ b/src/TextShow/Numeric/Natural.hs
+@@ -18,7 +18,11 @@ Portability: GHC
+ module TextShow.Numeric.Natural () where
+ 
+ #if MIN_VERSION_base(4,8,0)
++# if  !defined(TOOL_VERSION_eta)
+ import GHC.Integer.GMP.Internals (Integer(..))
++# else
++import GHC.Integer (Integer(..))
++# endif
+ import GHC.Natural (Natural(..))
+ import GHC.Types (Word(..))
+ #else
+@@ -30,7 +34,7 @@ import TextShow.Data.Integral ()
+ 
+ -- | /Since: 2/
+ instance TextShow Natural where
+-#if MIN_VERSION_base(4,8,0)
++#if MIN_VERSION_base(4,8,0) && !defined(TOOL_VERSION_eta)
+     showbPrec _ (NatS# w#)  = showb $ W# w#
+     showbPrec p (NatJ# bn)  = showbPrec p $ Jp# bn
+ #else
+diff --git a/src/TextShow/System/Posix/Types.hs b/src/TextShow/System/Posix/Types.hs
+index de1c2af..1fce9c0 100644
+--- a/src/TextShow/System/Posix/Types.hs
++++ b/src/TextShow/System/Posix/Types.hs
+@@ -27,7 +27,9 @@ import TextShow.Data.Integral   ()
+ import TextShow.Foreign.C.Types ()
+ import TextShow.Foreign.Ptr     ()
+ 
++#if !defined(TOOL_VERSION_eta)
+ #include "HsBaseConfig.h"
++#endif
+ 
+ #if defined(HTYPE_DEV_T)
+ -- | /Since: 2/
+diff --git a/text-show.cabal b/text-show.cabal
+index 2c78f33..4000889 100644
+--- a/text-show.cabal
++++ b/text-show.cabal
+@@ -162,7 +162,6 @@ library
+                      , contravariant         >= 0.5    && < 2
+                      , generic-deriving      >= 1.11   && < 2
+                      , ghc-prim
+-                     , integer-gmp
+                      , nats                  >= 0.1    && < 2
+                      , semigroups            >= 0.17   && < 1
+                      , tagged                >= 0.4.4  && < 1
+@@ -190,6 +189,11 @@ library
+   else
+     build-depends:     transformers          == 0.4.*
+ 
++  if impl(eta)
++    build-depends:     integer
++  else
++    build-depends:     integer-gmp
++    
+   hs-source-dirs:      src, shared
+   default-language:    Haskell2010
+   ghc-options:         -Wall
+@@ -349,7 +353,7 @@ test-suite spec
+                      , hspec                 >= 2      && < 3
+                      , nats                  >= 0.1    && < 2
+                      , QuickCheck            >= 2.12   && < 2.14
+-                     , quickcheck-instances  >= 0.3.18 && < 0.4
++                     , quickcheck-instances  >= 0.3.18 && < 0.3.21
+                      , semigroups            >= 0.18.3 && < 1
+                      , tagged                >= 0.8.3  && < 1
+                      , template-haskell      >= 2.5    && < 2.16
+-- 
+2.16.2.windows.1
+


### PR DESCRIPTION
* I had to mark unbuildable the components 
  * `duckling-regen-exe`: needed to generate the haskell files (i think): it uses `haskell-src-exts` and reach the class size limit
  * `duckling-example-exe`: it uses snap-core
* I've not tested it at runtime

Fixes #143