### PR TITLE
Patched neat-interpolation-0.3.2.4 and time-compat-1.9.2

### DIFF
--- a/patches/neat-interpolation-0.3.2.4.patch
+++ b/patches/neat-interpolation-0.3.2.4.patch
@@ -1,0 +1,24 @@
+From 5c5cd4031542ae1bf7a5077419b21a284f88cd69 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Fri, 31 May 2019 23:42:35 +0200
+Subject: [PATCH] Patched
+
+---
+ library/NeatInterpolation/Parsing.hs | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/library/NeatInterpolation/Parsing.hs b/library/NeatInterpolation/Parsing.hs
+index d3933d5..0014785 100644
+--- a/library/NeatInterpolation/Parsing.hs
++++ b/library/NeatInterpolation/Parsing.hs
+@@ -2,6 +2,7 @@ module NeatInterpolation.Parsing where
+ 
+ import BasePrelude hiding (many, some, try, (<|>))
+ import Data.Text (Text, pack)
++import Data.Void (Void)
+ import Text.Megaparsec hiding (Line)
+ import Text.Megaparsec.Char
+ 
+-- 
+2.16.2.windows.1
+

--- a/patches/time-compat-1.9.2.cabal
+++ b/patches/time-compat-1.9.2.cabal
@@ -47,13 +47,13 @@ library
 
   build-depends:
     , base          <0 && >=4.3 && <4.14
-    , base-orphans  ^>=0.8.1
-    , deepseq       ^>=1.3.0.0 || ^>=1.4.1.1
-    , time          ^>=1.2.0.3 || ^>=1.4 || ^>=1.5.0.1 || ^>=1.6.0.1 || ^>=1.8.0.2 || ^>=1.9.2
+    , base-orphans  >=0.8.1 && <0.9
+    , deepseq       >=1.3.0.0 && <1.5
+    , time          >=1.2.0.3 && <1.10
 
   if flag(old-locale)
     build-depends:
-      , old-locale  ^>=1.0.0.2
+      , old-locale  >=1.0.0.2 && <1.1
       , time        >=0       && <1.5
 
   else
@@ -61,7 +61,7 @@ library
 
   if !impl(ghc >=8.0)
     build-depends:
-      , fail        ^>=4.9.0.0
+      , fail        >=4.9.0.0 && <4.10
       , semigroups  >=0.18.5  && <0.20
 
   exposed-modules:
@@ -94,4 +94,4 @@ test-suite instances
     , base
     , deepseq
     , time-compat
-    , HUnit ^>=1.6.0.0 || ^>=1.3.1.2
+    , HUnit >=1.6.0.0 && <1.7 || >=1.3.1.2 && <1.4

--- a/patches/time-compat-1.9.2.cabal
+++ b/patches/time-compat-1.9.2.cabal
@@ -1,0 +1,97 @@
+cabal-version: 2.2
+name:          time-compat
+version:       1.9.2
+tested-with:   GHC ==7.8.4 || ==7.6.3 || ==7.4.2
+synopsis:      Compatibility package for time
+description:
+  This packages tries to compat as much of @time@ features as possible.
+  .
+  /TODO:/ Difference type @ParseTime@ and @FormatTime@ instances are missing.
+
+category:      Time, Compatibility
+license:       BSD-3-Clause
+license-file:  LICENSE
+maintainer:    Oleg Grenrus <oleg.grenrus@iki.fi>
+author:        Ashley Yakeley
+
+tested-with:
+  GHC==7.0.4
+  GHC==7.2.2,
+  GHC==7.4.2,
+  GHC==7.6.3,
+  GHC==7.8.4,
+  GHC==7.10.3,
+  GHC==8.0.2,
+  GHC==8.2.2,
+  GHC==8.4.4,
+  GHC==8.6.5,
+  GHC==8.8.1
+
+source-repository head
+  type:      git
+  location:  https://github.com/phadej/time-compat.git
+
+
+flag old-locale
+  description: If true, use old-locale, otherwise use time 1.5 or newer.
+  manual:      False
+  default:     False
+
+library
+  default-language: Haskell2010
+  hs-source-dirs:   src
+  other-extensions: CPP
+
+  if impl(ghc >=7.2)
+    default-extensions: Trustworthy
+
+  build-depends:
+    , base          <0 && >=4.3 && <4.14
+    , base-orphans  ^>=0.8.1
+    , deepseq       ^>=1.3.0.0 || ^>=1.4.1.1
+    , time          ^>=1.2.0.3 || ^>=1.4 || ^>=1.5.0.1 || ^>=1.6.0.1 || ^>=1.8.0.2 || ^>=1.9.2
+
+  if flag(old-locale)
+    build-depends:
+      , old-locale  ^>=1.0.0.2
+      , time        >=0       && <1.5
+
+  else
+    build-depends: time >=1.5
+
+  if !impl(ghc >=8.0)
+    build-depends:
+      , fail        ^>=4.9.0.0
+      , semigroups  >=0.18.5  && <0.20
+
+  exposed-modules:
+    Data.Time.Calendar.Compat
+    Data.Time.Calendar.Easter.Compat
+    Data.Time.Calendar.Julian.Compat
+    Data.Time.Calendar.MonthDay.Compat
+    Data.Time.Calendar.OrdinalDate.Compat
+    Data.Time.Calendar.WeekDate.Compat
+    Data.Time.Clock.Compat
+    Data.Time.Clock.POSIX.Compat
+    Data.Time.Clock.System.Compat
+    Data.Time.Clock.TAI.Compat
+    Data.Time.Compat
+    Data.Time.Format.Compat
+    Data.Time.Format.ISO8601.Compat
+    Data.Time.LocalTime.Compat
+
+  other-modules:
+    Data.Format
+    Data.Time.Calendar.Private
+    Data.Time.Orphans
+
+test-suite instances
+  default-language: Haskell2010
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Test.hs
+  build-depends:
+    , base
+    , deepseq
+    , time-compat
+    , HUnit ^>=1.6.0.0 || ^>=1.3.1.2

--- a/patches/time-compat-1.9.2.cabal
+++ b/patches/time-compat-1.9.2.cabal
@@ -46,14 +46,14 @@ library
     default-extensions: Trustworthy
 
   build-depends:
-    , base          <0 && >=4.3 && <4.14
+      base          <0 && >=4.3 && <4.14
     , base-orphans  >=0.8.1 && <0.9
     , deepseq       >=1.3.0.0 && <1.5
     , time          >=1.2.0.3 && <1.10
 
   if flag(old-locale)
     build-depends:
-      , old-locale  >=1.0.0.2 && <1.1
+        old-locale  >=1.0.0.2 && <1.1
       , time        >=0       && <1.5
 
   else
@@ -61,7 +61,7 @@ library
 
   if !impl(ghc >=8.0)
     build-depends:
-      , fail        >=4.9.0.0 && <4.10
+        fail        >=4.9.0.0 && <4.10
       , semigroups  >=0.18.5  && <0.20
 
   exposed-modules:
@@ -91,7 +91,7 @@ test-suite instances
   hs-source-dirs:   test
   main-is:          Test.hs
   build-depends:
-    , base
+      base
     , deepseq
     , time-compat
     , HUnit >=1.6.0.0 && <1.7 || >=1.3.1.2 && <1.4

--- a/patches/time-compat-1.9.2.patch
+++ b/patches/time-compat-1.9.2.patch
@@ -1,0 +1,25 @@
+From a9a57e835ad88caa970734d052bf4948a1a5a217 Mon Sep 17 00:00:00 2001
+From: jneira <atreyu.bbb@gmail.com>
+Date: Tue, 4 Jun 2019 22:24:52 +0200
+Subject: [PATCH] Patched
+
+---
+ time-compat.cabal | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/time-compat.cabal b/time-compat.cabal
+index e57c68e..18d2860 100644
+--- a/time-compat.cabal
++++ b/time-compat.cabal
+@@ -46,7 +46,7 @@ library
+     default-extensions: Trustworthy
+ 
+   build-depends:
+-    , base          >=4.3     && <4.14
++    , base          <0 && >=4.3 && <4.14
+     , base-orphans  ^>=0.8.1
+     , deepseq       ^>=1.3.0.0 || ^>=1.4.1.1
+     , time          ^>=1.2.0.3 || ^>=1.4 || ^>=1.5.0.1 || ^>=1.6.0.1 || ^>=1.8.0.2 || ^>=1.9.2
+-- 
+2.16.2.windows.1
+


### PR DESCRIPTION
`Data.Void` is in the Prelude for ghc but no for eta?